### PR TITLE
Add Cloudwatch alarm/SNS notification for lambda invocation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## [Unreleased]
 
+## [0.2.0] - 2018-10-31
+### Added
+- [Lambda] Add outputs for `function_name` and `function_arn`.
+- [Lambda] Add option SNS alerts on Lambda error by passing in SNS topic ARNs to `error_topics`.
+
 ## [0.1.0] - 2018-10-30
 ### Changed
 - [ECS Cluster] Update to Amazon 2 ECS optimized AMI.

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -78,7 +78,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda" {
  * Alerting
  */
 resource "aws_cloudwatch_metric_alarm" "alarm" {
-  count = "${var.error_topics}"
+  count = "${length(var.error_topics)}"
   alarm_name = "${var.name}-failures"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods = 1
@@ -89,5 +89,6 @@ resource "aws_cloudwatch_metric_alarm" "alarm" {
   dimensions {
     FunctionName = "${aws_lambda_function.default.function_name}"
   }
+  alarm_actions             = ["${element(var.error_topics, count.index)}"]
   treat_missing_data = "ignore"
 }

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -73,3 +73,21 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda" {
   principal = "events.amazonaws.com"
   source_arn = "${element(aws_cloudwatch_event_rule.schedule.*.arn, count.index)}"
 }
+
+/**
+ * Alerting
+ */
+resource "aws_cloudwatch_metric_alarm" "alarm" {
+  count = "${var.error_topics}"
+  alarm_name = "${var.name}-failures"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods = 1
+  metric_name = "Errors"
+  namespace = "AWS/Lambda"
+  period = 60
+  threshold = 1
+  dimensions {
+    FunctionName = "${aws_lambda_function.default.function_name}"
+  }
+  treat_missing_data = "ignore"
+}

--- a/lambda/outputs.tf
+++ b/lambda/outputs.tf
@@ -1,0 +1,10 @@
+
+// Lambda function ARN.
+output "function_arn" {
+  value = "${aws_lambda_function.default.arn}"
+}
+
+// Lambda function name.
+output "function_name" {
+  value = "${aws_lambda_function.default.function_name}"
+}

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -47,3 +47,8 @@ variable "tags" {
   type = "map"
   default = {}
 }
+variable "error_topics" {
+  type = "list"
+  description = "An array of SNS topics to publish notifications to when the function errors out"
+  default = []
+}


### PR DESCRIPTION
Adds an optional SNS topic notification for Lambda invocations that result in errors.  This can be tied into the Slack alerts system to notify anytime a lambda fails.   