### PR TITLE
Move to schedulev2

### DIFF
--- a/asg/main.tf
+++ b/asg/main.tf
@@ -22,7 +22,7 @@ resource "aws_launch_template" "default" {
     resource_type = "instance"
 
     tags = "${merge(var.tags, map(
-      "scheduler:ec2-startstop", "${var.instance_schedule}",
+      "schedulev2", "${var.instance_schedule}",
       "Patch Group", "${var.instance_patch_group}",
       "backup", "${var.instance_backup}"
     ))}"
@@ -32,7 +32,7 @@ resource "aws_launch_template" "default" {
     resource_type = "volume"
 
     tags = "${merge(var.tags, map(
-      "scheduler:ec2-startstop", "${var.instance_schedule}",
+      "schedulev2", "${var.instance_schedule}",
       "Patch Group", "${var.instance_patch_group}",
       "backup", "${var.instance_backup}"
     ))}"


### PR DESCRIPTION
This PR update the MDS' Terraform common modules to use `schedulev2`.