### PR TITLE
Add log group pre-creation so we can set a retention policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ Changelog
 
 ## [Unreleased]
 
+## [0.4.0] - 2018-11-26
+### Changed
+- [Lambda] Create log group as part of Lambda module so we are able to specify the retention policy.  Note: This will require that existing log groups are deleted or imported (using `terraform import`) before applying.
+
+## [0.3.0] - 2018-11-19
+### Changed
+- [ASG] Update to schedulerv2 tags to support EOTSS requirements.
+
 ## [0.2.0] - 2018-10-31
 ### Added
 - [Lambda] Add outputs for `function_name` and `function_arn`.

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -19,6 +19,17 @@ resource "aws_lambda_function" "default" {
   ))}"
 }
 
+/**
+ * Logging
+ */
+resource "aws_cloudwatch_log_group" "logs" {
+  name = "/aws/lambda/${var.name}"
+  retention_in_days = 30
+  tags = "${merge(var.tags, map(
+      "Name", "${var.name}"
+  ))}"
+}
+
 
 /**
  * Roles/Permissioning

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -97,6 +97,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm" {
   namespace = "AWS/Lambda"
   period = 60
   threshold = 1
+  statistic = "Sum"
   dimensions {
     FunctionName = "${aws_lambda_function.default.function_name}"
   }


### PR DESCRIPTION
This PR adds log group creation to the Lambda module.  If we don't pre-create it, it gets created by AWS with a retention policy of "forever."  This leads to logs piling up and costing us money.

In a future iteration, this could be made configurable, but none of the use cases we have right now require long term log retention. 