### PR TITLE
Add Terraform static site module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -69,6 +69,7 @@ resource "aws_cloudfront_distribution" "sub_domain_distribution" {
 
     forwarded_values {
       query_string = true
+      headers      = ["Host"]
       cookies {
         forward = "none"
       }

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -98,18 +98,18 @@ resource "aws_cloudfront_distribution" "sub_domain_distribution" {
 
 }
 
-// tld should already exist
-data "aws_route53_zone" "tld" {
-  name = "${var.zone}"
+
+// We want AWS to host our zone so its nameservers can point to our CloudFront
+// distribution.
+resource "aws_route53_zone" "zone" {
+  name = "${var.root_domain_name}"
 }
 
-
-// subdomain to add
-resource "aws_route53_record" "subdomain" {
-  zone_id = "${aws_route53_zone.tld.zone_id}"
+// This Route53 record will point at our CloudFront distribution.
+resource "aws_route53_record" "www" {
+  zone_id = "${aws_route53_zone.zone.zone_id}"
   name    = "${var.sub_domain_name}"
   type    = "CNAME"
-  ttl     = "${var.dns_ttl}"
 
   alias = {
     name                   = "${aws_cloudfront_distribution.sub_domain_distribution.domain_name}"

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -1,6 +1,6 @@
 // S3
-// static site bucket
-resource "aws_s3_bucket" "static_site" {
+// site bucket
+resource "aws_s3_bucket" "site" {
   // name bucket after sub-domain name
   bucket = "${var.sub_domain_name}"
   policy = <<POLICY
@@ -82,7 +82,7 @@ data "aws_lambda_function" "s3_headers" {
 resource "aws_cloudfront_distribution" "sub_domain_distribution" {
   origin {
     // S3 bucker url
-    domain_name = "${aws_s3_bucket.static_site.website_endpoint}"
+    domain_name = "${aws_s3_bucket.site.website_endpoint}"
 
     // identifies the origin with a name (can be any string of choice)
     origin_id   = "${var.sub_domain_name}"
@@ -154,5 +154,5 @@ resource "aws_cloudfront_distribution" "sub_domain_distribution" {
 // Cloudfront
 // create an identity to access origin
 resource "aws_cloudfront_origin_access_identity" "edge" {
-    comment = "Cloudfront ID for ${aws_s3_bucket.static_site.bucket}"
+    comment = "Cloudfront ID for ${aws_s3_bucket.site.bucket}"
 }

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -1,10 +1,11 @@
-// S3 site bucket
+// S3
+// site bucket
 resource "aws_s3_bucket" "site" {
   // name bucket after domain name
   bucket = "${var.domain_name}"
 }
 
-
+//IAM
 // OAI (Origin Access Identity) policy document
 data "aws_iam_policy_document" "oai_read" {
   statement {
@@ -28,7 +29,8 @@ data "aws_iam_policy_document" "oai_read" {
   }
 }
 
-// Apply policy to site bucket
+// S3
+// Apply policy to bucket
 resource "aws_s3_bucket_policy" "default" {
   bucket = "${aws_s3_bucket.site.id}"
   policy = "${data.aws_iam_policy_document.oai_read.json}"
@@ -155,7 +157,6 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
   }
 
   tags = "${var.tags}"
-
 }
 
 

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -87,6 +87,7 @@ resource "aws_cloudfront_distribution" "sub_domain_distribution" {
   // serve with cert
   viewer_certificate {
     acm_certificate_arn = "${aws_acm_certificate.certificate.arn}"
+    minimum_protocol_version = "TLSv1"
     ssl_support_method  = "sni-only"
   }
 }

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -3,6 +3,7 @@
 resource "aws_s3_bucket" "site" {
   // name bucket after domain name
   bucket = "${var.domain_name}"
+
   website {
     index_document = "index.html"
     error_document = "404.html"
@@ -40,11 +41,11 @@ resource "aws_s3_bucket_policy" "default" {
   policy = "${data.aws_iam_policy_document.oai_read.json}"
 }
 
-
 // AWS Certificate Manager
 // TLS/SSL certificate for the new domain
 resource "aws_acm_certificate" "default" {
-  domain_name       = "${var.domain_name}"
+  domain_name = "${var.domain_name}"
+
   // rely on a DNS entry for validating the certificate
   validation_method = "DNS"
 }
@@ -85,7 +86,7 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
     domain_name = "${aws_s3_bucket.site.website_endpoint}"
 
     // identifies the origin with a name (can be any string of choice)
-    origin_id   = "${var.domain_name}"
+    origin_id = "${var.domain_name}"
 
     // since the s3 bucker is not directly accessed by the public
     // identity to access the cloudfront distro
@@ -98,8 +99,8 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
   default_root_object = "index.html"
 
   custom_error_response {
-    error_code = "404"
-    response_code = "200"
+    error_code         = "404"
+    response_code      = "404"
     response_page_path = "/404.html"
   }
 
@@ -115,6 +116,7 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
 
     forwarded_values {
       query_string = true
+
       cookies {
         forward = "none"
       }
@@ -127,16 +129,17 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
   restrictions {
     geo_restriction {
       restriction_type = "none"
+
       // list of countries e.g. ["US", "CA", "GB", "DE"]
-      locations        = []
+      locations = []
     }
   }
 
   // serve with cert
   viewer_certificate {
-    acm_certificate_arn = "${aws_acm_certificate.default.arn}"
+    acm_certificate_arn      = "${aws_acm_certificate.default.arn}"
     minimum_protocol_version = "TLSv1"
-    ssl_support_method  = "sni-only"
+    ssl_support_method       = "sni-only"
   }
 
   tags = "${var.tags}"
@@ -145,5 +148,5 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
 // Cloudfront
 // create an identity to access origin
 resource "aws_cloudfront_origin_access_identity" "edge" {
-    comment = "Cloudfront ID for ${aws_s3_bucket.site.bucket}"
+  comment = "Cloudfront ID for ${aws_s3_bucket.site.bucket}"
 }

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -2,7 +2,6 @@
 resource "aws_s3_bucket" "mds_static_site" {
   // bucket's name = domain name
   bucket = "${var.sub_domain_name}"
-  acl    = "public-read"
   // We also need to create a policy that allows anyone to view the content.
   // This is basically duplicating what we did in the ACL but it's required by
   // AWS. This post: http://amzn.to/2Fa04ul explains why.

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -41,13 +41,6 @@ resource "aws_s3_bucket_policy" "default" {
 }
 
 
-// Route 53
-// TLD (Top Level Domain): zone where domains are added
-data "aws_route53_zone" "tld" {
-  name = "${var.root_domain_name}"
-}
-
-
 // AWS Certificate Manager
 // TLS/SSL certificate for the new domain
 resource "aws_acm_certificate" "default" {
@@ -63,7 +56,7 @@ resource "aws_acm_certificate" "default" {
 resource "aws_route53_record" "verification" {
   name    = "${aws_acm_certificate.default.domain_validation_options.0.resource_record_name}"
   type    = "${aws_acm_certificate.default.domain_validation_options.0.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.tld.zone_id}"
+  zone_id = "${var.zone_id}"
   records = ["${aws_acm_certificate.default.domain_validation_options.0.resource_record_value}"]
   ttl     = "60"
 }

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -50,6 +50,12 @@ data "aws_iam_policy_document" "oai_read" {
   }
 }
 
+// Apply policy to site bucket
+resource "aws_s3_bucket_policy" "default" {
+  bucket = "${aws_s3_bucket.default.id}"
+  policy = "${data.aws_iam_policy_document.oai_read.json}"
+}
+
 
 // Route 53
 // zone where subdomains are added

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -4,8 +4,8 @@ resource "aws_s3_bucket" "site" {
   // name bucket after domain name
   bucket = "${var.domain_name}"
   website {
-  index_document = "index.html"
-  error_document = "404.html"
+    index_document = "index.html"
+    error_document = "404.html"
   }
 }
 

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -23,13 +23,8 @@ resource "aws_s3_bucket" "mds_static_site" {
 }
 POLICY
 
-  // S3 understands what it means to host a website.
   website {
-    // Here we tell S3 what to use when a request comes in to the root
-    // ex. https://www.youssefriahi.com
     index_document = "index.html"
-    // The page to serve up if a request results in an error or a non-existing
-    // page.
     error_document = "404.html"
   }
 }

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -78,15 +78,15 @@ resource "aws_acm_certificate_validation" "default" {
 
 
 // Lambda
-// get "AlwaysRequestIndexHTML" lambda and store its metadata
-data "aws_lambda_function" "index_html" {
+// "AlwaysRequestIndexHTML"
+resource "aws_lambda_function" "index_html" {
   function_name = "${var.always_get_index_html_lambda}"
 }
 
 
 // Lambda
-// get the "s3_edge_header" lambda and store its metadata
-data "aws_lambda_function" "s3_headers" {
+// "s3_edge_header"
+resource "aws_lambda_function" "s3_headers" {
   function_name = "${var.s3_edge_header_lambda}"
 }
 
@@ -127,16 +127,16 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
     default_ttl            = 3600
     max_ttl                = 86400
 
-    // associate the "AlwaysRequestIndexHTML" lambda with CF
+    // associate "AlwaysRequestIndexHTML" lambda with CF
     lambda_function_association {
       event_type = "origin-request"
-      lambda_arn = "${data.aws_lambda_function.index_html.arn}"
+      lambda_arn = "${aws_lambda_function.index_html.arn}"
     }
 
-    // associate the "s3_edge_header" lambda with CF
+    // associate "s3_edge_header" lambda with CF
     lambda_function_association {
       event_type = "origin-response"
-      lambda_arn = "${data.aws_lambda_function.s3_headers.arn}"
+      lambda_arn = "${aws_lambda_function.s3_headers.arn}"
     }
 
     forwarded_values {

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -49,7 +49,6 @@ resource "aws_acm_certificate" "default" {
   validation_method = "DNS"
 }
 
-
 // Route 53
 // dns record to use for certificate validation
 // create the DNS entry in th relevant zone
@@ -61,14 +60,12 @@ resource "aws_route53_record" "verification" {
   ttl     = "60"
 }
 
-
 // Route 53
 // validate the certificate with dns entry
 resource "aws_acm_certificate_validation" "default" {
   certificate_arn         = "${aws_acm_certificate.default.arn}"
   validation_record_fqdns = ["${aws_route53_record.verification.fqdn}"]
 }
-
 
 // Route 53
 // Add CNAME entry for domain
@@ -144,7 +141,6 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
 
   tags = "${var.tags}"
 }
-
 
 // Cloudfront
 // create an identity to access origin

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -1,6 +1,6 @@
 // S3 site bucket
 resource "aws_s3_bucket" "site" {
-  // name bucket after sub-domain name
+  // name bucket after domain name
   bucket = "${var.domain_name}"
 }
 
@@ -36,14 +36,14 @@ resource "aws_s3_bucket_policy" "default" {
 
 
 // Route 53
-// zone where subdomains are added
+// zone where domains are added
 data "aws_route53_zone" "tld" {
   name = "${var.root_domain_name}"
 }
 
 
 // AWS Certificate Manager
-// TLS/SSL certificate for the subdomain
+// TLS/SSL certificate for the new domain
 resource "aws_acm_certificate" "default" {
   domain_name       = "${var.domain_name}"
   // rely on a DNS entry for validating the certificate
@@ -86,7 +86,7 @@ data "aws_lambda_function" "s3_headers" {
 
 
 // Cloudfront
-// cdn the subdomain
+// cdn the domain
 resource "aws_cloudfront_distribution" "domain_distribution" {
   origin {
     // S3 bucker url
@@ -136,7 +136,7 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
     }
   }
 
-  // hit Cloudfront using the sub domain url
+  // hit Cloudfront using the domain url
   aliases = ["${var.domain_name}"]
 
   restrictions {

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -27,6 +27,30 @@ POLICY
 }
 
 
+// OAI (Origin Access Identity) policy document
+data "aws_iam_policy_document" "oai_read" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.site.arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${aws_cloudfront_origin_access_identity.edge.iam_arn}"]
+    }
+  }
+
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = ["${aws_s3_bucket.site.arn}"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${aws_cloudfront_origin_access_identity.edge.iam_arn}"]
+    }
+  }
+}
+
+
 // Route 53
 // zone where subdomains are added
 data "aws_route53_zone" "tld" {

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -56,16 +56,17 @@ resource "aws_acm_certificate_validation" "default" {
 // Cloudfront
 resource "aws_cloudfront_distribution" "sub_domain_distribution" {
   origin {
-    custom_origin_config {
-      http_port              = "80"
-      https_port             = "443"
-      origin_protocol_policy = "http-only"
-      origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
-    }
-
     // S3 bucker url
     domain_name = "${aws_s3_bucket.mds_static_site.website_endpoint}"
+
+    // identifies the origin with a name (can be any string of choice)
     origin_id   = "${var.sub_domain_name}"
+
+    // since the s3 bucker is not directly accessed by the public
+    // identity to access the cloudfront distro
+    s3_origin_config {
+      origin_access_identity = "${aws_cloudfront_origin_access_identity.edge.cloudfront_access_identity_path}"
+    }
   }
 
   enabled             = true

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "oai_read" {
 
 // Apply policy to site bucket
 resource "aws_s3_bucket_policy" "default" {
-  bucket = "${aws_s3_bucket.default.id}"
+  bucket = "${aws_s3_bucket.site.id}"
   policy = "${data.aws_iam_policy_document.oai_read.json}"
 }
 

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -79,14 +79,14 @@ resource "aws_acm_certificate_validation" "default" {
 
 // Lambda
 // "AlwaysRequestIndexHTML"
-resource "aws_lambda_function" "index_html" {
+resource "aws_lambda_function" "origin_request_lambda" {
   function_name = "${var.always_get_index_html_lambda}"
 }
 
 
 // Lambda
 // "s3_edge_header"
-resource "aws_lambda_function" "s3_headers" {
+resource "aws_lambda_function" "origin_response_lambda" {
   function_name = "${var.s3_edge_header_lambda}"
 }
 
@@ -130,13 +130,13 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
     // associate "AlwaysRequestIndexHTML" lambda with CF
     lambda_function_association {
       event_type = "origin-request"
-      lambda_arn = "${aws_lambda_function.index_html.arn}"
+      lambda_arn = "${aws_lambda_function.origin_request_lambda.arn}"
     }
 
     // associate "s3_edge_header" lambda with CF
     lambda_function_association {
       event_type = "origin-response"
-      lambda_arn = "${aws_lambda_function.s3_headers.arn}"
+      lambda_arn = "${aws_lambda_function.origin_response_lambda.arn}"
     }
 
     forwarded_values {

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -1,9 +1,7 @@
 // S3
 resource "aws_s3_bucket" "mds_static_site" {
-  // Our bucket's name is going to be the same as our site's domain name.
+  // bucket's name = domain name
   bucket = "${var.sub_domain_name}"
-  // Because we want our site to be available on the internet, we set this so
-  // anyone can read this bucket.
   acl    = "public-read"
   // We also need to create a policy that allows anyone to view the content.
   // This is basically duplicating what we did in the ACL but it's required by
@@ -32,7 +30,7 @@ POLICY
 
 // TLS/SSL certificate
 resource "aws_acm_certificate" "subdomain_certificate" {
-  // We want a wildcard cert so we can host subdomains later.
+  // wildcard cert if we want to host sub-subdomains later.
   domain_name       = "*.${var.sub_domain_name}"
   validation_method = "DNS"
 }
@@ -50,7 +48,6 @@ resource "aws_cloudfront_distribution" "sub_domain_distribution" {
 
     // S3 bucker url
     domain_name = "${aws_s3_bucket.mds_static_site.website_endpoint}"
-    // This can be any name to identify this origin.
     origin_id   = "${var.sub_domain_name}"
   }
 
@@ -99,13 +96,13 @@ resource "aws_cloudfront_distribution" "sub_domain_distribution" {
 }
 
 
-// We want AWS to host our zone so its nameservers can point to our CloudFront
-// distribution.
+// root/zone
 resource "aws_route53_zone" "zone" {
   name = "${var.root_domain_name}"
 }
 
-// This Route53 record will point at our CloudFront distribution.
+
+// point Route53 record will point at our CloudFront distribution.
 resource "aws_route53_record" "www" {
   zone_id = "${aws_route53_zone.zone.zone_id}"
   name    = "${var.sub_domain_name}"

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -84,4 +84,9 @@ resource "aws_cloudfront_distribution" "sub_domain_distribution" {
     }
   }
 
+  // serve with cert
+  viewer_certificate {
+    acm_certificate_arn = "${aws_acm_certificate.certificate.arn}"
+    ssl_support_method  = "sni-only"
+  }
 }

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -70,6 +70,16 @@ resource "aws_acm_certificate_validation" "default" {
 }
 
 
+// Route 53
+// Add CNAME entry for domain
+resource "aws_route53_record" "default" {
+  zone_id = "${var.zone_id}"
+  name    = "${var.domain_name}"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["${aws_cloudfront_distribution.domain_distribution.domain_name}"]
+}
+
 // Lambda
 // "AlwaysRequestIndexHTML"
 resource "aws_lambda_function" "origin_request_lambda" {

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -75,6 +75,9 @@ resource "aws_cloudfront_distribution" "sub_domain_distribution" {
     }
   }
 
+  // hit Cloudfront distribution using sub domain url
+  aliases = ["${var.sub_domain_name}"]
+
   restrictions {
     geo_restriction {
       restriction_type = "none"

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -57,9 +57,15 @@ resource "aws_acm_certificate_validation" "default" {
 }
 
 
-// get lambda information and store its metadata
+// get "AlwaysRequestIndexHTML" lambda and store its metadata
 data "aws_lambda_function" "index_html" {
   function_name = "${var.always_get_index_html_lambda}"
+}
+
+
+// get the "s3_edge_header" lambda and store its metadata
+data "aws_lambda_function" "s3_headers" {
+  function_name = "${var.s3_edge_header_lambda}"
 }
 
 
@@ -93,10 +99,16 @@ resource "aws_cloudfront_distribution" "sub_domain_distribution" {
     default_ttl            = 3600
     max_ttl                = 86400
 
-    // associate the "AlwaysRequestIndexHTML" lambda
+    // associate the "AlwaysRequestIndexHTML" lambda with CF
     lambda_function_association {
       event_type = "origin-request"
       lambda_arn = "${data.aws_lambda_function.index_html.arn}"
+    }
+
+    // associate the "s3_edge_header" lambda with CF
+    lambda_function_association {
+      event_type = "origin-response"
+      lambda_arn = "${data.aws_lambda_function.s3_headers.arn}"
     }
 
     forwarded_values {

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -1,15 +1,7 @@
-// S3
-// site bucket
+// S3 site bucket
 resource "aws_s3_bucket" "site" {
   // name bucket after sub-domain name
   bucket = "${var.sub_domain_name}"
-
-  website {
-    // bucket root index file
-    // subfolders are handled by a lambda@edge
-    index_document = "index.html"
-    error_document = "404.html"
-  }
 }
 
 

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -1,0 +1,34 @@
+resource "aws_s3_bucket" "www" {
+  // Our bucket's name is going to be the same as our site's domain name.
+  bucket = "${var.sub_domain_name}"
+  // Because we want our site to be available on the internet, we set this so
+  // anyone can read this bucket.
+  acl    = "public-read"
+  // We also need to create a policy that allows anyone to view the content.
+  // This is basically duplicating what we did in the ACL but it's required by
+  // AWS. This post: http://amzn.to/2Fa04ul explains why.
+  policy = <<POLICY
+{
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Sid":"AddPerm",
+      "Effect":"Allow",
+      "Principal": "*",
+      "Action":["s3:GetObject"],
+      "Resource":["arn:aws:s3:::${var.sub_domain_name}/*"]
+    }
+  ]
+}
+POLICY
+
+  // S3 understands what it means to host a website.
+  website {
+    // Here we tell S3 what to use when a request comes in to the root
+    // ex. https://www.youssefriahi.com
+    index_document = "index.html"
+    // The page to serve up if a request results in an error or a non-existing
+    // page.
+    error_document = "404.html"
+  }
+}

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -100,7 +100,7 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
 
   custom_error_response {
     error_code         = "404"
-    response_code      = "404"
+    response_code      = "200"
     response_page_path = "${var.error_document}"
   }
 

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -6,7 +6,7 @@ resource "aws_s3_bucket" "site" {
 
   website {
     index_document = "index.html"
-    error_document = "404.html"
+    error_document = "${var.error_document}"
   }
 }
 
@@ -101,7 +101,7 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
   custom_error_response {
     error_code         = "404"
     response_code      = "404"
-    response_page_path = "/404.html"
+    response_page_path = "${var.error_document}"
   }
 
   default_cache_behavior {

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -1,11 +1,15 @@
 // S3
-// site bucket
+// Site bucket
 resource "aws_s3_bucket" "site" {
   // name bucket after domain name
   bucket = "${var.domain_name}"
+  website {
+  index_document = "index.html"
+  error_document = "404.html"
+  }
 }
 
-//IAM
+// IAM
 // OAI (Origin Access Identity) policy document
 data "aws_iam_policy_document" "oai_read" {
   statement {
@@ -38,7 +42,7 @@ resource "aws_s3_bucket_policy" "default" {
 
 
 // Route 53
-// zone where domains are added
+// TLD (Top Level Domain): zone where domains are added
 data "aws_route53_zone" "tld" {
   name = "${var.root_domain_name}"
 }
@@ -106,6 +110,12 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
 
   enabled             = true
   default_root_object = "index.html"
+
+  custom_error_response {
+  error_code = "404"
+  response_code = "200"
+  response_page_path = "/404.html"
+  }
 
   default_cache_behavior {
     viewer_protocol_policy = "redirect-to-https"

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -131,3 +131,7 @@ resource "aws_route53_record" "www" {
     evaluate_target_health = false
   }
 }
+
+resource "aws_cloudfront_origin_access_identity" "edge" {
+    comment = "Cloudfront ID for ${aws_s3_bucket.mds_static_site.bucket}"
+}

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -3,20 +3,6 @@
 resource "aws_s3_bucket" "site" {
   // name bucket after sub-domain name
   bucket = "${var.sub_domain_name}"
-  policy = <<POLICY
-{
-  "Version":"2012-10-17",
-  "Statement":[
-    {
-      "Sid":"AddPerm",
-      "Effect":"Allow",
-      "Principal": "*",
-      "Action":["s3:GetObject"],
-      "Resource":["arn:aws:s3:::${var.sub_domain_name}/*"]
-    }
-  ]
-}
-POLICY
 
   website {
     // bucket root index file

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -53,6 +53,13 @@ resource "aws_acm_certificate_validation" "default" {
   validation_record_fqdns = ["${aws_route53_record.default.fqdn}"]
 }
 
+
+// get lambda information and store its metadata
+data "aws_lambda_function" "index_html" {
+  function_name = "${var.always_get_index_html_lambda}"
+}
+
+
 // Cloudfront
 resource "aws_cloudfront_distribution" "sub_domain_distribution" {
   origin {

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -80,20 +80,6 @@ resource "aws_route53_record" "default" {
   records = ["${aws_cloudfront_distribution.domain_distribution.domain_name}"]
 }
 
-// Lambda
-// "AlwaysRequestIndexHTML"
-resource "aws_lambda_function" "origin_request_lambda" {
-  function_name = "${var.always_get_index_html_lambda}"
-}
-
-
-// Lambda
-// "s3_edge_header"
-resource "aws_lambda_function" "origin_response_lambda" {
-  function_name = "${var.s3_edge_header_lambda}"
-}
-
-
 // Cloudfront
 // cdn the domain
 resource "aws_cloudfront_distribution" "domain_distribution" {
@@ -129,18 +115,6 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
     min_ttl                = 0
     default_ttl            = 3600
     max_ttl                = 86400
-
-    // associate "AlwaysRequestIndexHTML" lambda with CF
-    lambda_function_association {
-      event_type = "origin-request"
-      lambda_arn = "${aws_lambda_function.origin_request_lambda.arn}"
-    }
-
-    // associate "s3_edge_header" lambda with CF
-    lambda_function_association {
-      event_type = "origin-response"
-      lambda_arn = "${aws_lambda_function.origin_response_lambda.arn}"
-    }
 
     forwarded_values {
       query_string = true

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -68,7 +68,7 @@ resource "aws_cloudfront_distribution" "sub_domain_distribution" {
     max_ttl                = 31536000
 
     forwarded_values {
-      query_string = false
+      query_string = true
       cookies {
         forward = "none"
       }

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -1,7 +1,7 @@
 // S3
 // static site bucket
-resource "aws_s3_bucket" "mds_static_site" {
-  // name bucker after sub-domain name
+resource "aws_s3_bucket" "static_site" {
+  // name bucket after sub-domain name
   bucket = "${var.sub_domain_name}"
   policy = <<POLICY
 {
@@ -83,7 +83,7 @@ data "aws_lambda_function" "s3_headers" {
 resource "aws_cloudfront_distribution" "sub_domain_distribution" {
   origin {
     // S3 bucker url
-    domain_name = "${aws_s3_bucket.mds_static_site.website_endpoint}"
+    domain_name = "${aws_s3_bucket.static_site.website_endpoint}"
 
     // identifies the origin with a name (can be any string of choice)
     origin_id   = "${var.sub_domain_name}"
@@ -155,5 +155,5 @@ resource "aws_cloudfront_distribution" "sub_domain_distribution" {
 // Cloudfront
 // create an identity to access origin
 resource "aws_cloudfront_origin_access_identity" "edge" {
-    comment = "Cloudfront ID for ${aws_s3_bucket.mds_static_site.bucket}"
+    comment = "Cloudfront ID for ${aws_s3_bucket.static_site.bucket}"
 }

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -56,7 +56,7 @@ resource "aws_acm_certificate" "default" {
 // Route 53
 // dns record to use for certificate validation
 // create the DNS entry in th relevant zone
-resource "aws_route53_record" "default" {
+resource "aws_route53_record" "verification" {
   name    = "${aws_acm_certificate.default.domain_validation_options.0.resource_record_name}"
   type    = "${aws_acm_certificate.default.domain_validation_options.0.resource_record_type}"
   zone_id = "${data.aws_route53_zone.tld.zone_id}"
@@ -69,7 +69,7 @@ resource "aws_route53_record" "default" {
 // validate the certificate with dns entry
 resource "aws_acm_certificate_validation" "default" {
   certificate_arn         = "${aws_acm_certificate.default.arn}"
-  validation_record_fqdns = ["${aws_route53_record.default.fqdn}"]
+  validation_record_fqdns = ["${aws_route53_record.verification.fqdn}"]
 }
 
 

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -37,3 +37,48 @@ resource "aws_acm_certificate" "certificate" {
   validation_method = "DNS"
 }
 
+
+// Cloudfront
+resource "aws_cloudfront_distribution" "sub_domain_distribution" {
+  origin {
+    custom_origin_config {
+      http_port              = "80"
+      https_port             = "443"
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+    }
+
+    // S3 bucker url
+    domain_name = "${aws_s3_bucket.mds_static_site.website_endpoint}"
+    // This can be any name to identify this origin.
+    origin_id   = "${var.sub_domain_name}"
+  }
+
+  enabled             = true
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "${var.sub_domain_name}"
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+}

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -1,5 +1,5 @@
 // S3
-resource "aws_s3_bucket" "www" {
+resource "aws_s3_bucket" "mds_static_site" {
   // Our bucket's name is going to be the same as our site's domain name.
   bucket = "${var.sub_domain_name}"
   // Because we want our site to be available on the internet, we set this so

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -82,6 +82,8 @@ resource "aws_cloudfront_distribution" "sub_domain_distribution" {
   restrictions {
     geo_restriction {
       restriction_type = "none"
+      // list of countries e.g. ["US", "CA", "GB", "DE"]
+      locations        = []
     }
   }
 

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -90,4 +90,7 @@ resource "aws_cloudfront_distribution" "sub_domain_distribution" {
     minimum_protocol_version = "TLSv1"
     ssl_support_method  = "sni-only"
   }
+
+  tags = "${var.tags}"
+
 }

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -97,3 +97,23 @@ resource "aws_cloudfront_distribution" "sub_domain_distribution" {
   tags = "${var.tags}"
 
 }
+
+// tld should already exist
+data "aws_route53_zone" "tld" {
+  name = "${var.zone}"
+}
+
+
+// subdomain to add
+resource "aws_route53_record" "subdomain" {
+  zone_id = "${aws_route53_zone.tld.zone_id}"
+  name    = "${var.sub_domain_name}"
+  type    = "CNAME"
+  ttl     = "${var.dns_ttl}"
+
+  alias = {
+    name                   = "${aws_cloudfront_distribution.sub_domain_distribution.domain_name}"
+    zone_id                = "${aws_cloudfront_distribution.sub_domain_distribution.hosted_zone_id}"
+    evaluate_target_health = false
+  }
+}

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -1,3 +1,4 @@
+// S3
 resource "aws_s3_bucket" "www" {
   // Our bucket's name is going to be the same as our site's domain name.
   bucket = "${var.sub_domain_name}"
@@ -32,3 +33,12 @@ POLICY
     error_document = "404.html"
   }
 }
+
+
+// TLS/SSL certificate
+resource "aws_acm_certificate" "certificate" {
+  // We want a wildcard cert so we can host subdomains later.
+  domain_name       = "*.${var.sub_domain_name}"
+  validation_method = "DNS"
+}
+

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -37,8 +37,7 @@ data "aws_route53_zone" "tld" {
 // AWS Certificate Manager
 // TLS/SSL certificate for the subdomain
 resource "aws_acm_certificate" "default" {
-  // wildcard cert if we want to host sub-subdomains later
-  domain_name       = "*.${var.sub_domain_name}"
+  domain_name       = "${var.sub_domain_name}"
   // rely on a DNS entry for validating the certificate
   validation_method = "DNS"
 }

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -31,7 +31,7 @@ POLICY
 
 
 // TLS/SSL certificate
-resource "aws_acm_certificate" "certificate" {
+resource "aws_acm_certificate" "subdomain_certificate" {
   // We want a wildcard cert so we can host subdomains later.
   domain_name       = "*.${var.sub_domain_name}"
   validation_method = "DNS"
@@ -89,7 +89,7 @@ resource "aws_cloudfront_distribution" "sub_domain_distribution" {
 
   // serve with cert
   viewer_certificate {
-    acm_certificate_arn = "${aws_acm_certificate.certificate.arn}"
+    acm_certificate_arn = "${aws_acm_certificate.subdomain_certificate.arn}"
     minimum_protocol_version = "TLSv1"
     ssl_support_method  = "sni-only"
   }

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -1,7 +1,7 @@
 // S3 site bucket
 resource "aws_s3_bucket" "site" {
   // name bucket after sub-domain name
-  bucket = "${var.sub_domain_name}"
+  bucket = "${var.domain_name}"
 }
 
 
@@ -45,7 +45,7 @@ data "aws_route53_zone" "tld" {
 // AWS Certificate Manager
 // TLS/SSL certificate for the subdomain
 resource "aws_acm_certificate" "default" {
-  domain_name       = "${var.sub_domain_name}"
+  domain_name       = "${var.domain_name}"
   // rely on a DNS entry for validating the certificate
   validation_method = "DNS"
 }
@@ -87,13 +87,13 @@ data "aws_lambda_function" "s3_headers" {
 
 // Cloudfront
 // cdn the subdomain
-resource "aws_cloudfront_distribution" "sub_domain_distribution" {
+resource "aws_cloudfront_distribution" "domain_distribution" {
   origin {
     // S3 bucker url
     domain_name = "${aws_s3_bucket.site.website_endpoint}"
 
     // identifies the origin with a name (can be any string of choice)
-    origin_id   = "${var.sub_domain_name}"
+    origin_id   = "${var.domain_name}"
 
     // since the s3 bucker is not directly accessed by the public
     // identity to access the cloudfront distro
@@ -110,7 +110,7 @@ resource "aws_cloudfront_distribution" "sub_domain_distribution" {
     compress               = true
     allowed_methods        = ["GET", "HEAD"]
     cached_methods         = ["GET", "HEAD"]
-    target_origin_id       = "${var.sub_domain_name}"
+    target_origin_id       = "${var.domain_name}"
     min_ttl                = 0
     default_ttl            = 3600
     max_ttl                = 86400
@@ -137,7 +137,7 @@ resource "aws_cloudfront_distribution" "sub_domain_distribution" {
   }
 
   // hit Cloudfront using the sub domain url
-  aliases = ["${var.sub_domain_name}"]
+  aliases = ["${var.domain_name}"]
 
   restrictions {
     geo_restriction {

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -112,9 +112,9 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
   default_root_object = "index.html"
 
   custom_error_response {
-  error_code = "404"
-  response_code = "200"
-  response_page_path = "/404.html"
+    error_code = "404"
+    response_code = "200"
+    response_page_path = "/404.html"
   }
 
   default_cache_behavior {
@@ -141,7 +141,6 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
 
     forwarded_values {
       query_string = true
-      headers      = ["Host"]
       cookies {
         forward = "none"
       }

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -16,16 +16,16 @@ variable "domain_name" {
 }
 
 // lambda to associate with a CloudFront distribution
-variable "origin_request" {
+variable "origin_request_lambda_arn" {
   type        = "string"
-  description = "The lambda arn to associate with the CloudFront Distribution."
+  description = "Lambda origin-request arn to associate with the CloudFront."
 
 }
 
 // lambda to associate with a CloudFront distribution
-variable "origin_response" {
+variable "origin_response_lambda_arn" {
   type        = "string"
-  description = "The lambda arn to associate with the CloudFront Distribution."
+  description = "Lambda origin-response arn to associate with the CloudFront."
 
 }
 

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -1,4 +1,4 @@
-# aws region
+// aws region
 provider "aws" {
   region = "us-east-1"
 }
@@ -15,20 +15,14 @@ variable "domain_name" {
   description = "The full domain name being added."
 }
 
-// get index.html lambda
-variable "always_get_index_html_lambda" {
-  type    = "string"
-  default = "AlwaysRequestIndexHTML"
-  description = "The lambda that always get index.html for sites."
+// lambda to associate with a CloudFront distribution
+variable "lambda_arn" {
+  type        = "string"
+  description = "The lambda arn to associate with the CloudFront Distribution."
+
 }
 
-// add headers lambda
-variable "s3_edge_header_lambda" {
-  type    = "string"
-  default = "s3_edge_header"
-  description = "The lamda that adds s3 origin headers."
-}
-
+// tags
 variable "tags" {
   type    = "map"
   default = {}

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -8,3 +8,56 @@ variable "sub_domain_name" {
   type        = "string"
   description = "The full sub domain name"
 }
+
+
+variable "zone" {
+  type        = "string"
+  description = "The domain name for the DNS zone"
+}
+
+variable "origin" {
+  type        = "string"
+  description = "The origin to connect back to"
+}
+
+variable "origin_policy" {
+  type        = "string"
+  description = "The policy to use when connecting to the origin"
+}
+
+variable "cdn_token" {
+  type        = "string"
+  description = "The value to add in the CDN-FWD header for all requests that pass through to the origin."
+  default     = ""
+}
+
+variable "dns_ttl" {
+  type    = "string"
+  default = "300"
+}
+
+variable "comment" {
+  type    = "string"
+  default = ""
+}
+
+variable "health_check_path" {
+  type        = "string"
+  description = "A URL path to use for health checks on this domain."
+  default     = ""
+}
+
+variable "notification_topic" {
+  type        = "string"
+  description = "The SNS topic ARN to notify when health checks fail."
+  default     = ""
+}
+
+variable "name" {
+  type = "string"
+}
+
+variable "tags" {
+  type    = "map"
+  default = {}
+}

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -14,13 +14,19 @@ variable "sub_domain_name" {
   description = "The full sub domain name"
 }
 
-variable "tags" {
-  type    = "map"
-  default = {}
-}
-
 variable "always_get_index_html_lambda" {
   type    = "string"
   default = "AlwaysRequestIndexHTML"
-  description = "The lamdas that alwasy gets index.html for static sites"
+  description = "The lambda that always get index.html for static sites"
+}
+
+variable "s3_edge_header_lambda" {
+  type    = "string"
+  default = "s3_edge_header"
+  description = "The lamda that adds s3 origin headers"
+}
+
+variable "tags" {
+  type    = "map"
+  default = {}
 }

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -3,64 +3,15 @@ provider "aws" {
   region = "us-east-1"
 }
 
-// new statis sites are subdomains under *.digital.mass.gov
-variable "sub_domain_name" {
-  type        = "string"
-  description = "The full sub domain name"
-}
-
-
-// We'll also need the root domain (also known as zone apex or naked domain).
+// root domain name
 variable "root_domain_name" {
   default = "digital.mass.gov"
 }
 
-
-variable "zone" {
+// new statis sites are subdomains under *.digital.mass.gov
+variable "sub_domain_name" {
   type        = "string"
-  description = "The domain name for the DNS zone"
-}
-
-variable "origin" {
-  type        = "string"
-  description = "The origin to connect back to"
-}
-
-variable "origin_policy" {
-  type        = "string"
-  description = "The policy to use when connecting to the origin"
-}
-
-variable "cdn_token" {
-  type        = "string"
-  description = "The value to add in the CDN-FWD header for all requests that pass through to the origin."
-  default     = ""
-}
-
-variable "dns_ttl" {
-  type    = "string"
-  default = "300"
-}
-
-variable "comment" {
-  type    = "string"
-  default = ""
-}
-
-variable "health_check_path" {
-  type        = "string"
-  description = "A URL path to use for health checks on this domain."
-  default     = ""
-}
-
-variable "notification_topic" {
-  type        = "string"
-  description = "The SNS topic ARN to notify when health checks fail."
-  default     = ""
-}
-
-variable "name" {
-  type = "string"
+  description = "The full sub domain name"
 }
 
 variable "tags" {

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -4,8 +4,9 @@ provider "aws" {
 }
 
 // root domain name
-variable "root_domain_name" {
-  default = "digital.mass.gov"
+variable "zone_id" {
+  type        = "string"
+  description = "The zone that domain will be added to"
 }
 
 // new site domain name

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -8,8 +8,8 @@ variable "root_domain_name" {
   default = "digital.mass.gov"
 }
 
-// new statis sites are subdomains under *.digital.mass.gov
-variable "sub_domain_name" {
+// new domain name
+variable "domain_name" {
   type        = "string"
   description = "The full sub domain name"
 }

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -16,7 +16,14 @@ variable "domain_name" {
 }
 
 // lambda to associate with a CloudFront distribution
-variable "lambda_arn" {
+variable "origin_request" {
+  type        = "string"
+  description = "The lambda arn to associate with the CloudFront Distribution."
+
+}
+
+// lambda to associate with a CloudFront distribution
+variable "origin_response" {
   type        = "string"
   description = "The lambda arn to associate with the CloudFront Distribution."
 

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -1,0 +1,10 @@
+# aws region
+provider "aws" {
+  region = "us-east-1"
+}
+
+// new statis sites are subdomains under *.digital.mass.gov
+variable "sub_domain_name" {
+  type        = "string"
+  description = "The full sub domain name"
+}

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -18,3 +18,9 @@ variable "tags" {
   type    = "map"
   default = {}
 }
+
+variable "always_get_index_html_lambda" {
+  type    = "string"
+  default = "AlwaysRequestIndexHTML"
+  description = "The lamdas that alwasy gets index.html for static sites"
+}

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -6,25 +6,27 @@ provider "aws" {
 // root domain name
 variable "zone_id" {
   type        = "string"
-  description = "The zone that domain will be added to"
+  description = "The zone that domain will be added to."
 }
 
 // new site domain name
 variable "domain_name" {
   type        = "string"
-  description = "The full domain name"
+  description = "The full domain name being added."
 }
 
+// get index.html lambda
 variable "always_get_index_html_lambda" {
   type    = "string"
   default = "AlwaysRequestIndexHTML"
-  description = "The lambda that always get index.html for static sites"
+  description = "The lambda that always get index.html for sites."
 }
 
+// add headers lambda
 variable "s3_edge_header_lambda" {
   type    = "string"
   default = "s3_edge_header"
-  description = "The lamda that adds s3 origin headers"
+  description = "The lamda that adds s3 origin headers."
 }
 
 variable "tags" {

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -10,6 +10,12 @@ variable "sub_domain_name" {
 }
 
 
+// We'll also need the root domain (also known as zone apex or naked domain).
+variable "root_domain_name" {
+  default = "digital.mass.gov"
+}
+
+
 variable "zone" {
   type        = "string"
   description = "The domain name for the DNS zone"

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -8,10 +8,10 @@ variable "root_domain_name" {
   default = "digital.mass.gov"
 }
 
-// new domain name
+// new site domain name
 variable "domain_name" {
   type        = "string"
-  description = "The full sub domain name"
+  description = "The full domain name"
 }
 
 variable "always_get_index_html_lambda" {

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -22,6 +22,12 @@ variable "lambda_arn" {
 
 }
 
+// error document
+variable "error_document" {
+  default = "/404.html"
+  description = "The error document being used for errors."
+}
+
 // tags
 variable "tags" {
   type    = "map"


### PR DESCRIPTION
This PR introduces a Terraform module that handles static sites to be launched under digital.mass.gov.

- Assumes that the new sites are going under *.digital.mass.gov.
- Provisions a cert for the new subdomain being added.
- Validates the cert by adding a DNS entry in the proper Route zone.
- Associates the "AlwaysRequestIndexHTML" to deal with static sites' subfolders.
- Associates the existing "s3_edge_header" lambda to add header in S3 origin response.


Notes:
- Single App Page are not supported yet in this module.