### PR TITLE
Use ASG scheduling for ASGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 ## [Unreleased]
 
+## [0.7.0] - 2018-12-11
+### Added
+- [ASG] Add `schedule`, `schedule_down` and `schedule_up` properties, which control instance scheduling using the ASG scheduler.  Until we receive a config exception from EOTSS, these should be used in addition to the `schedulev2` tag (`instance_schedule` property).  Once the exception is granted, we should use `na` for the `schedulev2` tag, and exclusively use the ASG scheduling for all ASG instances. 
+
 ## [0.6.0] - 2018-12-10
 ### Added
 - [RDS Instance] Added RDS instance module to instantiate a single RDS instance (not appropriate for Aurora).

--- a/asg/main.tf
+++ b/asg/main.tf
@@ -45,8 +45,8 @@ resource "aws_autoscaling_group" "default" {
   }
 
   name                = "${var.name}"
-  max_size            = 10
-  min_size            = 1
+  max_size            = "${var.capacity}"
+  min_size            = "${var.capacity}"
   desired_capacity    = "${var.capacity}"
   vpc_zone_identifier = ["${var.subnets}"]
 
@@ -60,4 +60,24 @@ resource "aws_autoscaling_group" "default" {
     propagate_at_launch = false
     value               = "${var.name}"
   }
+}
+
+resource "aws_autoscaling_schedule" "schedule_down" {
+  count = "${var.schedule && var.schedule_down != "" ? 1 : 0}"
+  autoscaling_group_name = "${aws_autoscaling_group.default.name}"
+  scheduled_action_name = "schedule_down"
+  recurrence = "${var.schedule_down}"
+  min_size = 0
+  max_size = 0
+  desired_capacity = 0
+}
+
+resource "aws_autoscaling_schedule" "schedule_up" {
+  count = "${var.schedule && var.schedule_up != "" ? 1 : 0}"
+  autoscaling_group_name = "${aws_autoscaling_group.default.name}"
+  scheduled_action_name = "schedule_up"
+  recurrence = "${var.schedule_up}"
+  min_size = "${var.capacity}"
+  max_size = "${var.capacity}"
+  desired_capacity = "${var.capacity}"
 }

--- a/asg/variables.tf
+++ b/asg/variables.tf
@@ -60,7 +60,7 @@ variable "schedule" {
 variable "schedule_down" {
   type = "string"
   description = "A cron expression indicating when to schedule the ASG to scale down to 0 instances (defaults to 7PM EST weekdays)."
-  default = "00 00 * * 1-5"
+  default = "59 23 * * 1-5"
 }
 
 variable "schedule_up" {

--- a/asg/variables.tf
+++ b/asg/variables.tf
@@ -51,14 +51,34 @@ variable "keypair" {
   description = "The name of an SSH keypair to attach to all instances."
 }
 
+variable "schedule" {
+  type = "string"
+  description = "A boolean indicating whether to automatically schedule the ASG according to the `schedule_down` and `schedule_up` variables."
+  default = false
+}
+
+variable "schedule_down" {
+  type = "string"
+  description = "A cron expression indicating when to schedule the ASG to scale down to 0 instances (defaults to 7PM EST weekdays)."
+  default = "00 00 * * 1-5"
+}
+
+variable "schedule_up" {
+  type = "string"
+  description = "A cron expression indicating when to schedule the ASG to scale up to $capacity instances (defaults to 7AM EST weekdays)"
+  default = "00 12 * * 1-5"
+}
+
 variable "instance_schedule" {
   type        = "string"
-  description = "The schedule on which to start and stop EC2 instances. Can be `na` or `1100;2300;utc;weekdays`, depending on whether this is a dev or prod environment."
+  description = "The value to use for the instance scheduling tag (schedulev2). Defaults to `na` for ASG instances, because ASGs should be scheduled via the ASG scheduler."
+  default = "na"
 }
 
 variable "instance_backup" {
   type        = "string"
   description = "Backup instructions for EC2 instances"
+  default = "na"
 }
 
 variable "instance_patch_group" {


### PR DESCRIPTION
This PR implements ASG scheduling for managing the instance schedule of ASG instances.  This is a trial run for implementing ASG scheduling in place of the `schedulev2` tag throughout our account. 

Specifically, we're expecting that:
* Max capacity for the ASG will drop to $capacity (1 in this case).
* A new scheduling rule for bringing $capacity down to 0 at 7PM EST will be created.
* A new scheduling rule for bringing $capacity up to $original_capacity at 7AM EST will be created.

This PR isn't ready for prime-time yet - it's being tested in https://github.com/massgov/DS-Infrastructure/pull/68.