### PR TITLE
[Lambda] Fix an error that was causing the lambda module to fail when…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 ## [Unreleased]
 
+## [0.10.0] - 2019-01-30
+### Fixed
+- [Lambda] Fix an error that was causing the lambda module to fail when invoked with an empty schedule ({}).
+
 ## [0.9.0] - 2018-12-13
 ### Changed
 - [RDS Instance] Set sane defaults for the maintenance window, snapshot tagging, and deletion protection.

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -78,7 +78,7 @@ resource "aws_cloudwatch_event_target" "schedule_target" {
 }
 resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda" {
   count = "${aws_cloudwatch_event_rule.schedule.count}"
-  statement_id = "${var.name}-${element(keys(var.schedule), count.index)}"
+  statement_id = "${element(aws_cloudwatch_event_rule.schedule.*.name, count.index)}"
   action = "lambda:InvokeFunction"
   function_name = "${aws_lambda_function.default.function_name}"
   principal = "events.amazonaws.com"


### PR DESCRIPTION
… invoked with an empty schedule ({}) (#14)