### PR TITLE
Allow lambda@edge to assume lambda role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ Changelog
 
 ## [Unreleased]
 
+## [0.11.0] - 2019-02-01
+### BREAKING
+- [Lambda] Remove `environment_variables` option.  It's been replaced by `environment`.
+### Added
+- [Lambda] Add `environment` option for lambda.  This is the new way to specify environment variables for a Lambda function.  The old way would not allow us to have no environment variables (required for Lambda@Edge).
+### Changed
+- [Lambda] Allow lambda@edge to assume the created Lambda role.
+- [Lambda] Use function versioning.
+
 ## [0.10.0] - 2019-01-30
 ### Fixed
 - [Lambda] Fix an error that was causing the lambda module to fail when invoked with an empty schedule ({}).

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -12,7 +12,14 @@ resource "aws_lambda_function" "default" {
     security_group_ids = ["${var.security_groups}"]
     subnet_ids = ["${var.subnets}"]
   }
-  environment = "${var.environment}"
+  # The aws_lambda_function resource has a schema for the environment
+  # variable, where the only acceptable values are:
+  #   a. Undefined
+  #   b. An empty list
+  #   c. A list containing 1 element: a map with a specific schema
+  # Use slice to get option "b" or "c" depending on whether a non-empty
+  # value was passed into this module.
+  environment = ["${slice( list(var.environment), 0, length(var.environment) == 0 ? 0 : 1 )}"]
   tags = "${merge(var.tags, map(
       "Name", "${var.name}"
   ))}"

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -7,6 +7,7 @@ resource "aws_lambda_function" "default" {
   source_code_hash = "${base64sha256(file("${var.package}"))}"
   runtime = "${var.runtime}"
   timeout = "${var.timeout}"
+  version = true
   vpc_config {
     security_group_ids = ["${var.security_groups}"]
     subnet_ids = ["${var.subnets}"]

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "assume" {
     principals {
       type = "Service"
       identifiers = [
-        "lambda.amazonaws.com"
+        "lambda.amazonaws.com",
         "edgelambda.amazonaws.com"
       ]
     }

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -7,7 +7,7 @@ resource "aws_lambda_function" "default" {
   source_code_hash = "${base64sha256(file("${var.package}"))}"
   runtime = "${var.runtime}"
   timeout = "${var.timeout}"
-  version = true
+  publish = true
   vpc_config {
     security_group_ids = ["${var.security_groups}"]
     subnet_ids = ["${var.subnets}"]

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -39,7 +39,10 @@ data "aws_iam_policy_document" "assume" {
     actions = ["sts:AssumeRole"]
     principals {
       type = "Service"
-      identifiers = ["lambda.amazonaws.com"]
+      identifiers = [
+        "lambda.amazonaws.com"
+        "edgelambda.amazonaws.com"
+      ]
     }
   }
 }

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -12,9 +12,7 @@ resource "aws_lambda_function" "default" {
     security_group_ids = ["${var.security_groups}"]
     subnet_ids = ["${var.subnets}"]
   }
-  environment {
-    variables = "${var.environment_variables}"
-  }
+  environment = "${local.environment}"
   tags = "${merge(var.tags, map(
       "Name", "${var.name}"
   ))}"

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -12,7 +12,7 @@ resource "aws_lambda_function" "default" {
     security_group_ids = ["${var.security_groups}"]
     subnet_ids = ["${var.subnets}"]
   }
-  environment = "${local.environment}"
+  environment = "${var.environment}"
   tags = "${merge(var.tags, map(
       "Name", "${var.name}"
   ))}"

--- a/lambda/outputs.tf
+++ b/lambda/outputs.tf
@@ -9,6 +9,11 @@ output "function_name" {
   value = "${aws_lambda_function.default.function_name}"
 }
 
+// Lambda function qualified ARN (includes current version string)
+output "function_qualified_arn" {
+  value = "${aws_lambda_function.default.qualified_arn}"
+}
+
 // Lambda function version.
 output "function_version" {
   value = "${aws_lambda_function.default.version}"

--- a/lambda/outputs.tf
+++ b/lambda/outputs.tf
@@ -8,3 +8,8 @@ output "function_arn" {
 output "function_name" {
   value = "${aws_lambda_function.default.function_name}"
 }
+
+// Lambda function version.
+output "function_version" {
+  value = "${aws_lambda_function.default.version}"
+}

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -24,7 +24,7 @@ variable "subnets" {
   type = "list"
   default = []
 }
-variable "environment_variables" {
+variable "environment" {
   type = "map"
   default = {}
 }


### PR DESCRIPTION
This PR adds the ability for the Lambda module to be used from Lambda@Edge.  In particular:
* Adds IAM perms for edge to assume the lambda role.
* Allows empty environment to be specified.
* Publishes versions of the function.