### PR TITLE
Add tags to ECS image packer template

### DIFF
--- a/packer/ecs_ssm.json
+++ b/packer/ecs_ssm.json
@@ -14,7 +14,20 @@
     },
     "ami_name": "itd-ds-ecs-optimized-ssm-{{timestamp}}",
     "instance_type": "t1.micro",
-    "ssh_username": "ec2-user"
+    "ssh_username": "ec2-user",
+    "run_tags": {
+      "Name": "packer-tmp-build-ebs",
+      "Patch Group": "nonprod-linux2",
+      "agency": "itd",
+      "application": "bastion",
+      "backup": "na",
+      "businessowner": "eotss-dl-digitalcloud@massmail.state.ma.us",
+      "createdby": "eotss-dl-digitalcloud@massmail.state.ma.us",
+      "environment": "mgt",
+      "itowner": "eotss-dl-digitalcloud@massmail.state.ma.us",
+      "schedulev2": "0700_1900_weekdays",
+      "secretariat": "eotss"
+    }
   }],
   "provisioners": [{
     "type": "shell",


### PR DESCRIPTION
This PR attempts to fix the issue where Packer causes images to be built without tags on them, generating notifications for EOTSS.  This adds tags to the image as Packer builds it.  
