### PR TITLE
Static-site: Use specific origin_id, remove unused variables

### DIFF
--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -109,7 +109,7 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
     compress               = true
     allowed_methods        = ["GET", "HEAD"]
     cached_methods         = ["GET", "HEAD"]
-    target_origin_id       = "${var.domain_name}"
+    target_origin_id       = "${var.origin_id}"
     min_ttl                = 0
     default_ttl            = 3600
     max_ttl                = 86400

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -83,10 +83,10 @@ resource "aws_route53_record" "default" {
 resource "aws_cloudfront_distribution" "domain_distribution" {
   origin {
     // S3 bucker url
-    domain_name = "${aws_s3_bucket.site.website_endpoint}"
+    domain_name = "${aws_s3_bucket.site.bucket_regional_domain_name}"
 
     // identifies the origin with a name (can be any string of choice)
-    origin_id = "${var.domain_name}"
+    origin_id = "${var.origin_id}"
 
     // since the s3 bucker is not directly accessed by the public
     // identity to access the cloudfront distro

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -21,19 +21,6 @@ variable "origin_id" {
   description = "Unique identifier for the CloudFront domain"
 }
 
-// lambda to associate with a CloudFront distribution
-variable "origin_request_lambda_arn" {
-  type        = "string"
-  description = "Lambda origin-request arn to associate with the CloudFront."
-}
-
-// lambda to associate with a CloudFront distribution
-variable "origin_response_lambda_arn" {
-  type        = "string"
-  description = "Lambda origin-response arn to associate with the CloudFront."
-
-}
-
 // error document
 variable "error_document" {
   default = "/404.html"

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -15,11 +15,16 @@ variable "domain_name" {
   description = "The full domain name being added."
 }
 
+// new site origin id
+variable "origin_id" {
+  type        = "string"
+  description = "Unique identifier for the CloudFront domain"
+}
+
 // lambda to associate with a CloudFront distribution
 variable "origin_request_lambda_arn" {
   type        = "string"
   description = "Lambda origin-request arn to associate with the CloudFront."
-
 }
 
 // lambda to associate with a CloudFront distribution

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -19,6 +19,7 @@ variable "domain_name" {
 variable "origin_id" {
   type        = "string"
   description = "Unique identifier for the CloudFront domain"
+  default = "default"
 }
 
 // error document


### PR DESCRIPTION
Terraform was complaining about using the domain for the origin id so this uses a user supplied string for it instead. Terraform also recommends using `bucket_regional_domain_name` instead of the `website_endpoint`, so this switches that as well.
ex:
- https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#example-usage
- https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#bucket_regional_domain_name

It also removes two variables that look like they're currently unused