### PR TITLE
Allow volume size and encryption to be changed in ECS Cluster, ASG

### DIFF
--- a/asg/main.tf
+++ b/asg/main.tf
@@ -10,6 +10,16 @@ resource "aws_launch_template" "default" {
   key_name               = "${var.keypair}"
   user_data              = "${var.user_data}"
 
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      volume_size = "${var.volume_size}"
+      volume_type = "gp2"
+      delete_on_termination = "true"
+      encrypted = "${var.volume_encryption}"
+    }
+  }
+
   credit_specification {
     cpu_credits = "standard"
   }

--- a/asg/variables.tf
+++ b/asg/variables.tf
@@ -22,6 +22,18 @@ variable "instance_type" {
   default     = "t3.nano"
 }
 
+variable "volume_size" {
+  type = "string"
+  description = "The EBS volume size to use for the root EBS volume"
+  default = 30
+}
+
+variable "volume_encryption" {
+  type = "string"
+  description = "A boolean indicating whether to encrypt the root EBS volume or not."
+  default = false
+}
+
 variable "security_groups" {
   type        = "list"
   description = "Security groups to apply to the instances."

--- a/ecscluster/main.tf
+++ b/ecscluster/main.tf
@@ -13,6 +13,8 @@ module "asg" {
   subnets              = "${var.subnets}"
   policies             = ["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"]
   user_data            = "${base64encode(data.template_file.instance_init.rendered)}"
+  volume_size = "${var.volume_size}"
+  volume_encryption = "${var.volume_encryption}"
   instance_schedule    = "${var.instance_schedule}"
   instance_patch_group = "${var.instance_patch_group}"
   instance_backup      = "${var.instance_backup}"

--- a/ecscluster/variables.tf
+++ b/ecscluster/variables.tf
@@ -38,6 +38,18 @@ variable "security_groups" {
   default     = []
 }
 
+variable "volume_size" {
+  type = "string"
+  description = "The EBS volume size to use for the root EBS volume"
+  default = 30
+}
+
+variable "volume_encryption" {
+  type = "string"
+  description = "A boolean indicating whether to encrypt the root EBS volume or not."
+  default = false
+}
+
 variable "schedule" {
   type = "string"
   description = "A boolean indicating whether to automatically schedule the ASG according to the `schedule_down` and `schedule_up` variables."


### PR DESCRIPTION
This PR allows setting an EBS volume size for the ASG and ECS Cluster modules.  This is necessary to support the ETLs, which require more disk space than the 30gb default volume. 