### PR TITLE
Chamber policy

### DIFF
--- a/chamberpolicy/README.md
+++ b/chamberpolicy/README.md
@@ -4,3 +4,27 @@ Chamber Policy
 This Terraform module renders IAM policies for reading or writing secrets stored with [Chamber](https://github.com/segmentio/chamber).
 
 It does not create any resources on its own - it only provides outputs for IAM policies that can be attached to IAM users, roles, or groups.
+
+Usage:
+
+```hcl-terraform
+
+# Invoke the module to formulate read and write policies
+# for a particular namespace.
+module "chamber_policy" {
+  source = "github.com/massgov/mds-terraform-common//chamberpolicy?ref=REPLACE_WITH_LATEST_VERSION"
+  namespace = "apps/mds-etl/nonprod"
+}
+
+# Attach a read only policy to a reader role.
+resource "aws_iam_role_policy" "chamber_read_attachment" {
+  role = "${aws_iam_role.reader.id}"
+  policy = "${chamber_policy.read_policy}"
+}
+
+# Attach a read/write policy to a "writer" role.
+resource "aws_iam_role_policy" "chamber_write_attachment" {
+  role = "${aws_iam_role.writer.id}"
+  policy = "${chamber_policy.readwrite_policy}"
+}
+```

--- a/chamberpolicy/README.md
+++ b/chamberpolicy/README.md
@@ -1,0 +1,6 @@
+Chamber Policy
+==============
+
+This Terraform module renders IAM policies for reading or writing secrets stored with [Chamber](https://github.com/segmentio/chamber).
+
+It does not create any resources on its own - it only provides outputs for IAM policies that can be attached to IAM users, roles, or groups.

--- a/chamberpolicy/main.tf
+++ b/chamberpolicy/main.tf
@@ -13,7 +13,6 @@ locals {
 
 data "aws_iam_policy_document" "read_policy" {
   statement {
-    sid = "Allow read access to SSM"
     actions = [
       "ssm:GetParameter",
       "ssm:GetParameters",
@@ -23,7 +22,6 @@ data "aws_iam_policy_document" "read_policy" {
     resources = ["${local.parameter_arn}"]
   }
   statement {
-    sid = "Allow decrypt access to KMS"
     actions = ["kms:Decrypt"]
     resources = ["${data.aws_kms_alias.chamber_key.arn}"]
     condition {
@@ -36,7 +34,6 @@ data "aws_iam_policy_document" "read_policy" {
 
 data "aws_iam_policy_document" "readwrite_policy" {
   statement {
-    sid = "Allow read/write access to SSM"
     actions = [
       "ssm:GetParameter",
       "ssm:GetParameters",
@@ -49,7 +46,6 @@ data "aws_iam_policy_document" "readwrite_policy" {
   }
   // Read (decrypt)
   statement {
-    sid = "Allow decrypt access to KMS"
     actions = ["kms:Decrypt"]
     resources = ["${data.aws_kms_alias.chamber_key.arn}"]
     condition {
@@ -60,7 +56,6 @@ data "aws_iam_policy_document" "readwrite_policy" {
   }
   // Write (encrypt)
   statement {
-    sid = "Allow encrypt access to KMS"
     actions = ["kms:Encrypt"]
     resources = ["${data.aws_kms_alias.chamber_key.arn}"]
   }

--- a/chamberpolicy/main.tf
+++ b/chamberpolicy/main.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "read_policy" {
   }
   statement {
     actions = ["kms:Decrypt"]
-    resources = ["${data.aws_kms_alias.chamber_key.arn}"]
+    resources = ["${data.aws_kms_alias.chamber_key.target_key_arn}"]
     condition {
       test = "StringEquals"
       values = ["${local.parameter_arn}"]
@@ -47,7 +47,7 @@ data "aws_iam_policy_document" "readwrite_policy" {
   // Read (decrypt)
   statement {
     actions = ["kms:Decrypt"]
-    resources = ["${data.aws_kms_alias.chamber_key.arn}"]
+    resources = ["${data.aws_kms_alias.chamber_key.target_key_arn}"]
     condition {
       test = "StringLike"
       values = ["${local.parameter_arn}"]
@@ -57,6 +57,6 @@ data "aws_iam_policy_document" "readwrite_policy" {
   // Write (encrypt)
   statement {
     actions = ["kms:Encrypt"]
-    resources = ["${data.aws_kms_alias.chamber_key.arn}"]
+    resources = ["${data.aws_kms_alias.chamber_key.target_key_arn}"]
   }
 }

--- a/chamberpolicy/main.tf
+++ b/chamberpolicy/main.tf
@@ -8,14 +8,13 @@ data "aws_kms_alias" "chamber_key" {
 locals {
   region = "${coalesce(var.region, data.aws_region.current.name)}"
   account_id = "${coalesce(var.account_id, data.aws_caller_identity.current.account_id)}"
-  all_parameters_arn = "arn:aws:ssm:${local.region}:${local.account_id}:parameter/*"
   namespace_parameters_arn = "arn:aws:ssm:${local.region}:${local.account_id}:parameter/${var.namespace}"
 }
 
 data "aws_iam_policy_document" "read_policy" {
   statement {
     actions = ["ssm:DescribeParameters"]
-    resources = ["arn:aws:ssm:${local.all_parameters_arn}"]
+    resources = ["*"]
   }
   statement {
     actions = [
@@ -39,7 +38,7 @@ data "aws_iam_policy_document" "read_policy" {
 data "aws_iam_policy_document" "readwrite_policy" {
   statement {
     actions = ["ssm:DescribeParameters"]
-    resources = ["arn:aws:ssm:${local.all_parameters_arn}"]
+    resources = ["*"]
   }
   statement {
     actions = [

--- a/chamberpolicy/main.tf
+++ b/chamberpolicy/main.tf
@@ -49,7 +49,7 @@ data "aws_iam_policy_document" "readwrite_policy" {
     actions = ["kms:Decrypt"]
     resources = ["${data.aws_kms_alias.chamber_key.arn}"]
     condition {
-      test = "StringEquals"
+      test = "StringLike"
       values = ["${local.parameter_arn}"]
       variable = "kms:EncryptionContext:PARAMETER_ARN"
     }

--- a/chamberpolicy/main.tf
+++ b/chamberpolicy/main.tf
@@ -1,0 +1,61 @@
+
+
+data "aws_caller_identity" "identity" {}
+data "aws_region" "region" {}
+data "aws_kms_alias" "chamber_key" {
+  name = "${var.key_alias}"
+}
+locals {
+  region = "${coalesce(var.region, data.aws_region.region.current)}"
+  account_id = "${coalesce(var.account_id, data.aws_caller_identity.identity.account_id)}"
+  parameter_arn = "arn:aws:ssm:${local.region}:${local.account_id}:parameter/${var.namespace}"
+}
+
+data "aws_iam_policy_document" "read_policy" {
+  statement {
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:DescribeParameters"
+    ]
+    resources = ["${local.parameter_arn}"]
+  }
+  statement {
+    actions = ["kms:Decrypt"]
+    resources = ["${data.aws_kms_alias.chamber_key.arn}"]
+    condition {
+      test = "StringEquals"
+      values = ["${local.parameter_arn}"]
+      variable = "kms:EncryptionContext:PARAMETER_ARN"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "readwrite_policy" {
+  statement {
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:GetParameterHistory",
+      "ssm:GetParametersByPath",
+      "ssm:PutParameter",
+      "ssm:DeleteParameter",
+      "ssm:DeleteParameters"
+    ]
+  }
+  // Read (decrypt)
+  statement {
+    actions = ["kms:Decrypt"]
+    resources = ["${data.aws_kms_alias.chamber_key.arn}"]
+    condition {
+      test = "StringEquals"
+      values = ["${local.parameter_arn}"]
+      variable = "kms:EncryptionContext:PARAMETER_ARN"
+    }
+  }
+  // Write (encrypt)
+  statement {
+    actions = ["kms:Encrypt"]
+    resources = ["${data.aws_kms_alias.chamber_key.arn}"]
+  }
+}

--- a/chamberpolicy/main.tf
+++ b/chamberpolicy/main.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "read_policy" {
     actions = ["kms:Decrypt"]
     resources = ["${data.aws_kms_alias.chamber_key.target_key_arn}"]
     condition {
-      test = "StringEquals"
+      test = "StringLike"
       values = ["${local.namespace_parameters_arn}"]
       variable = "kms:EncryptionContext:PARAMETER_ARN"
     }

--- a/chamberpolicy/main.tf
+++ b/chamberpolicy/main.tf
@@ -16,6 +16,7 @@ data "aws_iam_policy_document" "read_policy" {
     actions = [
       "ssm:GetParameter",
       "ssm:GetParameters",
+      "ssm:GetParametersByPath",
       "ssm:DescribeParameters"
     ]
     resources = ["${local.parameter_arn}"]

--- a/chamberpolicy/outputs.tf
+++ b/chamberpolicy/outputs.tf
@@ -1,0 +1,9 @@
+
+// The rendered JSON describing the read only IAM policy.
+output "read_policy" {
+  value = "${data.aws_iam_policy_document.read_policy.json}"
+}
+
+output "readwrite_policy" {
+  value = "${data.aws_iam_policy_document.readwrite_policy.json}"
+}

--- a/chamberpolicy/variables.tf
+++ b/chamberpolicy/variables.tf
@@ -1,0 +1,21 @@
+
+variable "region" {
+  type = "string"
+  description = "The AWS region to scope access to (defaults to current region)."
+  default = false
+}
+variable "account_id" {
+  type = "string"
+  description = "The AWS account ID to scope access to (defaults to current account)."
+  default = false
+
+}
+variable "key_alias" {
+  type = "string"
+  description = "The KMS key alias that is used for Chamber parameters."
+  default = "alias/parameter_store_key"
+}
+variable "namespace" {
+  type = "string"
+  description = "The Chamber namespace to create policies for."
+}

--- a/chamberpolicy/variables.tf
+++ b/chamberpolicy/variables.tf
@@ -2,12 +2,12 @@
 variable "region" {
   type = "string"
   description = "The AWS region to scope access to (defaults to current region)."
-  default = false
+  default = ""
 }
 variable "account_id" {
   type = "string"
   description = "The AWS account ID to scope access to (defaults to current account)."
-  default = false
+  default = ""
 
 }
 variable "key_alias" {


### PR DESCRIPTION
This PR adds a `chamberpolicy` module to produce secure, tested IAM policy documents for reading and writing KMS encrypted chamber parameters.