### PR TITLE
add flatten func

### DIFF
--- a/ecscluster/main.tf
+++ b/ecscluster/main.tf
@@ -6,9 +6,9 @@ module "asg" {
   instance_type = "${var.instance_type}"
   ami           = "${var.ami}"
 
-  security_groups = [
+  security_groups = flatten([
     "${var.security_groups}",
-  ]
+  ])
 
   subnets              = "${var.subnets}"
   policies             = ["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"]

--- a/rdsinstance/main.tf
+++ b/rdsinstance/main.tf
@@ -23,10 +23,10 @@ resource "aws_db_instance" "default" {
   db_subnet_group_name = "${aws_db_subnet_group.default.name}"
   performance_insights_enabled = true
   performance_insights_retention_period = 7
-  vpc_security_group_ids = [
+  vpc_security_group_ids = flatten([
     "${var.security_groups}",
     "${aws_security_group.db.id}"
-  ]
+  ])
   tags = "${merge(var.tags, map(
       "Name", "${var.name}",
       "Patch Group", "${var.instance_patch_group}",


### PR DESCRIPTION
This adds the function `flatten()` to the `ecscluster` and `rdsinstance` modules following a[ build failure](https://console.aws.amazon.com/codesuite/codebuild/projects/ETL-plan/build/ETL-plan%3A095832dc-1a8a-4c14-8787-7a841806c86e/log) when `1.0.0` was pulled into `ETL Terraform .12 upgrade`