### PR TITLE
RDS Instance mod update

### DIFF
--- a/rdsinstance/main.tf
+++ b/rdsinstance/main.tf
@@ -22,10 +22,10 @@ resource "aws_db_instance" "default" {
   db_subnet_group_name    = aws_db_subnet_group.default.name
   performance_insights_enabled = true
   performance_insights_retention_period = 7
-  vpc_security_group_ids = [
+  vpc_security_group_ids = flatten([
     var.security_groups,
     aws_security_group.db.id,
-  ]
+  ])
   tags = merge(
     var.tags,
     {


### PR DESCRIPTION
Updates the `rdsinstance` module to use `flatten()` for its `vpc_security_group_ids` 