### PR TITLE
Add create_before_destroy to static site ACM config

### DIFF
--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -55,6 +55,11 @@ resource "aws_acm_certificate" "default" {
 
   // rely on a DNS entry for validating the certificate
   validation_method = "DNS"
+
+  // Replace a certificate which is currently in use
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 // Route 53


### PR DESCRIPTION
Create a new ACM certificate and replace the existing one before destroying it to avoid unique name conflicts.