### PR TITLE
Add create_before_destroy to static site ACM config

### DIFF
--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -79,6 +79,10 @@ resource "aws_acm_certificate" "default" {
   tags = merge(var.tags, {
     "Name": var.name
   })
+  // Replace certificate that is currently in use
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 // Route 53


### PR DESCRIPTION
Against 1.x branch: Create a new ACM certificate and replace the existing one before destroying it to avoid unique name conflicts.