### PR TITLE
Install EC2 Instance Connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,17 @@
 
 ## [Unreleased]
 
+## [1.0.15] - 2019-09-19
+### Added
+- [ASG] Add EC2 instance connect to the default AMI.
+- [ECS Cluster] Add EC2 instance connect to the default AMI.
+
 ## [1.0.14] - 2019-09-17
+### Added
 - [ASG] Make ASG launch with the updated AmazonSSMManagedInstanceCore policy instead of the old SSM policy.
 
 ## [1.0.13] - 2019-09-17
+### Added
 - [ASG] Make ASG launch template EBS optimized.
 
 ## [1.0.10] - 2019-08-28

--- a/asg/variables.tf
+++ b/asg/variables.tf
@@ -7,7 +7,7 @@ variable "ami" {
   type        = string
   description = "The AMI ID to use for the instances. Keep this at the default value to automatically receive AMI updates to Amazon Linux 2"
   // AMI Built from packer/base.json
-  default     = "ami-0612f4612a1b42926"
+  default     = "ami-06309b45f2e91e084"
 }
 
 variable "capacity" {

--- a/ecscluster/variables.tf
+++ b/ecscluster/variables.tf
@@ -90,6 +90,6 @@ variable "ami" {
 
   // Custom AMI based on AWS Linux 2 ECS optimized
   // Also has SSM.  See packer build (/packer/ecs_ssm.json)
-  default = "ami-0413530c7d7a6a0ad"
+  default = "ami-05487cba5d54a92d8"
 }
 

--- a/packer/base.json
+++ b/packer/base.json
@@ -14,7 +14,6 @@
     },
     "ami_name": "itd-ds-base-{{timestamp}}",
     "instance_type": "t1.micro",
-    "ebs-optimized": true,
     "ssh_username": "ec2-user",
     "run_tags": {
       "Name": "packer-tmp-build-base",
@@ -35,6 +34,11 @@
       "type": "shell",
       "execute_command": "sudo -S sh -c '{{ .Vars }} {{ .Path }}'",
       "script": "scripts/ssm.sh"
+    },
+    {
+      "type": "shell",
+      "execute_command": "sudo -S sh -c '{{ .Vars }} {{ .Path }}'",
+      "script": "scripts/eic.sh"
     }
   ]
 }

--- a/packer/ecs_ssm.json
+++ b/packer/ecs_ssm.json
@@ -14,7 +14,6 @@
     },
     "ami_name": "itd-ds-ecs-optimized-ssm-{{timestamp}}",
     "instance_type": "t1.micro",
-    "ebs-optimized": true,
     "ssh_username": "ec2-user",
     "run_tags": {
       "Name": "packer-tmp-build-ebs",
@@ -35,6 +34,11 @@
       "type": "shell",
       "execute_command": "sudo -S sh -c '{{ .Vars }} {{ .Path }}'",
       "script": "scripts/ssm.sh"
+    },
+    {
+      "type": "shell",
+      "execute_command": "sudo -S sh -c '{{ .Vars }} {{ .Path }}'",
+      "script": "scripts/eic.sh"
     }
   ]
 }

--- a/packer/scripts/eic.sh
+++ b/packer/scripts/eic.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+yum install -y install ec2-instance-connect
+systemctl is-enabled ec2-instance-connect || systemctl enable ec2-instance-connect


### PR DESCRIPTION
This PR installs EC2 Instance Connect on our base AMIs.  This software allows fetching SSH keys from the Instance Connect API on demand, allowing developers to shell into machines using IAM permissions rather than relying on keys pre-placed on the machines.  This is part of a two-pronged approach where we allow connection to private-subnet instances with SSM Session Manager, and enable authentication using EIC. 