### PR TITLE
Repository types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [1.0.19] - 2020-03-25
+
+### Added
+
+- [PIPELINES] Add repository source type option to be able to use CODECOMMIT, BITBUCKET...etc
+- Keep `GITHUB` as default.
+
 ## [1.0.18] - 2020-02-04
 
 ### Changed

--- a/pipelines/pipeline/main.tf
+++ b/pipelines/pipeline/main.tf
@@ -33,7 +33,7 @@ resource "aws_codebuild_project" "plan" {
   }
   service_role = aws_iam_role.plan.arn
   source {
-    type                = "GITHUB"
+    type                = var.repository_type
     location            = var.repository
     git_clone_depth     = "1"
     report_build_status = true
@@ -100,7 +100,7 @@ resource "aws_codebuild_project" "apply_develop" {
   }
   service_role = aws_iam_role.apply.arn
   source {
-    type                = "GITHUB"
+    type                = var.repository_type
     location            = var.repository
     git_clone_depth     = "1"
     report_build_status = true
@@ -162,7 +162,7 @@ resource "aws_codebuild_project" "apply_master" {
   }
   service_role = aws_iam_role.apply.arn
   source {
-    type                = "GITHUB"
+    type                = var.repository_type
     location            = var.repository
     git_clone_depth     = "1"
     report_build_status = true

--- a/pipelines/pipeline/variables.tf
+++ b/pipelines/pipeline/variables.tf
@@ -8,6 +8,12 @@ variable "tags" {
   description = "A map of tags to apply to the codebuild jobs"
 }
 
+variable "repository_type" {
+  type        = string
+  description = "The type of repository that contains the source code to be built."
+  default     = "GITHUB"
+}
+
 variable "repository" {
   type        = string
   description = "The github repository URL"


### PR DESCRIPTION
This PR changes the repository type to become an input variable while keeping `GITHUB` as the default repository type. This would allow provisioning pipelines from other sources such as `CODECOMMIT`  or `BITBUCKET`.