### PR TITLE
Formatted Slack messages - DP-20492

### DIFF
--- a/slackalerts/src/index.js
+++ b/slackalerts/src/index.js
@@ -27,7 +27,7 @@ exports.handler = async function(data, context, callback) {
 
     // Special handling for formatting ClamAV alert subject and message.
     data.Records.forEach(function(element, index) {
-        if (element.Sns.TopicArn.contains('massgov-clamav-scan-status')) {
+        if (element.Sns.TopicArn.includes('massgov-clamav-scan-status')) {
             const message = JSON.parse(element.Sns.Message);
             let output = ' ';
             for (const [key, value] of Object.entries(message)) {


### PR DESCRIPTION
This PR adds some conditional code for ClamAV scanning. For this particular project, we don't have a lot of control over the source message's formatting, since it lives in a third-party GitHub project. So, it it seems like this repo might the cleanest place for the re-formatting to live.