### PR TITLE
RDS Snapshot and deletion options

### DIFF
--- a/rdsinstance/main.tf
+++ b/rdsinstance/main.tf
@@ -3,30 +3,31 @@ resource "aws_db_subnet_group" "default" {
   subnet_ids = var.subnets
 }
 
+
 // db instance
 resource "aws_db_instance" "default" {
-  identifier              = var.name
-  allocated_storage       = var.allocated_storage
-  storage_type            = "gp2"
-  engine                  = var.engine
-  engine_version          = var.engine_version
-  instance_class          = var.instance_class
-  username                = var.username
-  password                = var.password
-  backup_retention_period = var.backup_retention_period
-  copy_tags_to_snapshot   = true
-  deletion_protection     = true
-  maintenance_window      = "wed:04:00-wed:05:00"
-  storage_encrypted       = var.storage_encrypted
-  parameter_group_name    = var.parameter_group_name
-  db_subnet_group_name    = aws_db_subnet_group.default.name
-  performance_insights_enabled = var.performance_insights_enabled
+  identifier                            = var.name
+  allocated_storage                     = var.allocated_storage
+  storage_type                          = "gp2"
+  engine                                = var.engine
+  engine_version                        = var.engine_version
+  instance_class                        = var.instance_class
+  username                              = var.username
+  password                              = var.password
+  backup_retention_period               = var.backup_retention_period
+  copy_tags_to_snapshot                 = true
+  deletion_protection                   = var.deletion_protection
+  maintenance_window                    = "wed:04:00-wed:05:00"
+  storage_encrypted                     = var.storage_encrypted
+  parameter_group_name                  = var.parameter_group_name
+  db_subnet_group_name                  = aws_db_subnet_group.default.name
+  performance_insights_enabled          = var.performance_insights_enabled
   performance_insights_retention_period = var.performance_insights_retention_period
-  monitoring_interval     = var.monitoring_interval
-  auto_minor_version_upgrade  = var.auto_minor_version_upgrade
-  allow_major_version_upgrade = var.allow_major_version_upgrade
-  apply_immediately           = var.apply_immediately
-  iam_database_authentication_enabled = var.iam_database_authentication_enabled
+  monitoring_interval                   = var.monitoring_interval
+  auto_minor_version_upgrade            = var.auto_minor_version_upgrade
+  allow_major_version_upgrade           = var.allow_major_version_upgrade
+  apply_immediately                     = var.apply_immediately
+  iam_database_authentication_enabled   = var.iam_database_authentication_enabled
   vpc_security_group_ids = flatten([
     var.security_groups,
     aws_security_group.db.id,
@@ -40,6 +41,15 @@ resource "aws_db_instance" "default" {
       "backup"      = var.instance_backup
     },
   )
+
+  skip_final_snapshot       = var.skip_final_snapshot
+  final_snapshot_identifier = var.final_snapshot_identifier
+
+  snapshot_identifier = var.snapshot_identifier
+
+  lifecycle {
+    ignore_changes = [snapshot_identifier]
+  }
 }
 
 // db security group

--- a/rdsinstance/variables.tf
+++ b/rdsinstance/variables.tf
@@ -137,3 +137,27 @@ variable "backup_retention_period" {
   type        = number
   default     = 30
 }
+
+variable "deletion_protection" {
+  description = "Enables deletion protection. Handy to be able to turn off if you are cleaning up."
+  type        = bool
+  default     = true
+}
+
+variable "skip_final_snapshot" {
+  description = "Don't require a final snapshot upon deletion."
+  type        = bool
+  default     = null
+}
+
+variable "final_snapshot_identifier" {
+  description = "Name of final snapshot. Required if skip_final_snapshot is false."
+  type        = string
+  default     = null
+}
+
+variable "snapshot_identifier" {
+  description = "Snapshot to be used when creating a new RDS instance."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
While restoring the ETL dev database from a production snapshot, I needed these settings to be able to allow for deletion as well as be able to create a new instance from a designated snapshot.

This PR should not change any of the current default functionality since `null` values are used so they will be ignored or in the case of `deletion_protection` it defaults to true.