### PR TITLE
Allow configuration of ephemeral storage size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.28] - 2022-06-24
+
+- [LAMBDA] Allow configuration of ephemeral storage.
+
 ## [1.0.26] - 2020-01-25
 
 - [SLACKALERTS] Recreated slackalerts Lambda.

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -120,7 +120,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda" {
  */
 resource "aws_cloudwatch_metric_alarm" "alarm" {
   count               = length(var.error_topics)
-  alarm_name          = "${coalesce(var.human_name, var.name)} (${var. error"
+  alarm_name          = "${coalesce(var.human_name, var.name)} error"
   alarm_description   = "The Lambda function ${coalesce(var.human_name, var.name)} has errored"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -61,8 +61,8 @@ data "aws_iam_policy_document" "assume" {
     principals {
       type = "Service"
       identifiers = [
-        "lambda.amazonaws.com",
         "edgelambda.amazonaws.com",
+        "lambda.amazonaws.com",
       ]
     }
   }
@@ -120,7 +120,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda" {
  */
 resource "aws_cloudwatch_metric_alarm" "alarm" {
   count               = length(var.error_topics)
-  alarm_name          = "${coalesce(var.human_name, var.name)} error"
+  alarm_name          = "${coalesce(var.human_name, var.name)} (${var. error"
   alarm_description   = "The Lambda function ${coalesce(var.human_name, var.name)} has errored"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -12,6 +12,10 @@ resource "aws_lambda_function" "default" {
     security_group_ids = var.security_groups
     subnet_ids         = var.subnets
   }
+  
+  ephemeral_storage {
+    size = var.ephemeral_storage_size 
+  }
 
   # The aws_lambda_function resource has a schema for the environment
   # variable, where the only acceptable values are:

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -32,6 +32,12 @@ variable "memory_size" {
   description = "The memory limit for the Lambda Function"
 }
 
+variable "ephemeral_storage_size" {
+  type = string
+  default = 512
+  description = "The amount of ephemeral storage to provision for the Lambda"
+}
+
 variable "security_groups" {
   type    = list(string)
   default = []

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -4,7 +4,7 @@ variable "name" {
 
 variable "human_name" {
   type        = string
-  description = "A human readable name for the function (used in alerting)."
+  description = "A human readable name for the function (used in alerting). This name must be unique across environments!"
   default     = ""
 }
 


### PR DESCRIPTION
Three small improvements for the lambda module:
1. Allow ephemeral storage to be configured.
2. Prevent spurious/meaningless diffs on the assume role policy stemming from ordering of AWS service IDs.
3. Add a note to the human name description to indicate that the cloudwatch alarm name must be unique to avoid colliding Cloudwatch alarms. 