### PR TITLE
Allow static sites to override S3 expose_headers - DP-25255

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.31] - 2022-07-22
+
+- [Static Site] Add ability to override expose_headers.
+
 ## [1.0.30] - 2022-07-08
 
 - [CloudFront Geo-Restriction] Add helper module for projects and other modules that define CloudFront distributions.

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -26,7 +26,7 @@ resource "aws_s3_bucket" "site" {
       allowed_headers = var.cors_allowed_headers
       allowed_methods = var.cors_allowed_methods
       allowed_origins = var.cors_allowed_origins
-      expose_headers  = ["ETag"]
+      expose_headers  = var.cors_expose_headers
       max_age_seconds = 3600
     }
   }

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -82,6 +82,11 @@ variable "cors_allowed_origins" {
   default = ["*"]
 }
 
+variable "cors_expose_headers" {
+  type = list(string)
+  default = ["ETag"]
+}
+
 variable "is_spa" {
   type = string
   description = "A boolean indicating whether the site is a single page app. If it is, the index document will be used instead of a 404 response."


### PR DESCRIPTION
This PR allows the S3 bucket expose_headers value to be overridden by static-site modules.