### PR TITLE
Enhancements to Lambda module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.33] - 2022-10-05
+
+- [Lambda] Add `invoke_arn` output.
+- [Lambda] Add `publish` variable to control whether a new version is published.
+- [Lambda] Add `layers` variable to allow attachment of additional layers (created externally) to the function.
+
 ## [1.0.32] - 2022-07-22
 
 - [Domain Certificate] Add standalone module for domain certificates.

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -7,7 +7,7 @@ resource "aws_lambda_function" "default" {
   source_code_hash = filebase64sha256(var.package)
   runtime          = var.runtime
   timeout          = var.timeout
-  publish          = true
+  publish          = var.publish
   memory_size      = var.memory_size
   layers           = var.layers
   vpc_config {

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -9,6 +9,7 @@ resource "aws_lambda_function" "default" {
   timeout          = var.timeout
   publish          = true
   memory_size      = var.memory_size
+  layers           = var.layers
   vpc_config {
     security_group_ids = var.security_groups
     subnet_ids         = var.subnets

--- a/lambda/outputs.tf
+++ b/lambda/outputs.tf
@@ -22,3 +22,8 @@ output "function_version" {
 output "developer_policies" {
   value = [data.aws_iam_policy_document.developer.json]
 }
+
+// Lambda function's Invoke ARN.
+output "invoke_arn" {
+  value = aws_lambda_function.default.invoke_arn
+}

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -48,6 +48,11 @@ variable "subnets" {
   default = []
 }
 
+variable "layers" {
+  type    = list(string)
+  default = []
+}
+
 variable "environment" {
   type = object({
     variables = map(string)

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -21,6 +21,11 @@ variable "runtime" {
   type = string
 }
 
+variable "publish" {
+  type = boolean
+  default = true
+}
+
 variable "timeout" {
   type    = string
   default = 300

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -22,7 +22,7 @@ variable "runtime" {
 }
 
 variable "publish" {
-  type = boolean
+  type = bool
   default = true
 }
 


### PR DESCRIPTION
Has 3 small enhancements to the Lambda module:
1. Add `invoke_arn` output.
2. Add `publish` variable to control whether a new version is published. This can prevent old versions of the function from piling up and eventually hitting the max versions and needing manual intervention. 
3. Add `layers` variable to allow attachment of additional layers (created externally) to the function.