### PR TITLE
DP-27138: replace branch_filter with filter_group in pipeline config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.39] - 2023-02-02
+
+- [Pipelines] - Switch from `branch_filter` to `filter_group`.
+
 ## [1.0.38] - 2022-12-21
 
 - [Entrypoint Monitor] Grant read access to the SSM parameter.

--- a/pipelines/pipeline/main.tf
+++ b/pipelines/pipeline/main.tf
@@ -62,7 +62,8 @@ resource "aws_codebuild_webhook" "plan" {
 
     filter {
       type = "HEAD_REF"
-      pattern = "^refs/heads/(?!master|develop).*$"
+      pattern = "^refs/heads/(?:master|develop)$"
+      exclude_matched_pattern = true
     }
   }
 }

--- a/pipelines/pipeline/main.tf
+++ b/pipelines/pipeline/main.tf
@@ -53,12 +53,34 @@ resource "aws_codebuild_project" "plan" {
 
 resource "aws_codebuild_webhook" "plan" {
   project_name  = aws_codebuild_project.plan.name
-  branch_filter = "^(?!master|develop).*$"
+
+  filter_group {
+    filter {
+      type = "EVENT"
+      pattern = "PUSH, PULL_REQUEST_CREATED, PULL_REQUEST_UPDATED"
+    }
+
+    filter {
+      type = "HEAD_REF"
+      pattern = "^refs/heads/(?!master|develop).*$"
+    }
+  }
 }
 
 resource "aws_codebuild_webhook" "apply_develop" {
   project_name  = aws_codebuild_project.apply_develop.name
-  branch_filter = "^develop$"
+
+  filter_group {
+    filter {
+      type = "EVENT"
+      pattern = "PUSH, PULL_REQUEST_CREATED, PULL_REQUEST_UPDATED"
+    }
+
+    filter {
+      type = "HEAD_REF"
+      pattern = "^refs/heads/develop$"
+    }
+  }
 
   // We use a provisioner here to remove the pull_request event from the apply
   // webhook.  Otherwise, this codebuild job will run for every PR.
@@ -120,7 +142,18 @@ resource "aws_codebuild_project" "apply_develop" {
 
 resource "aws_codebuild_webhook" "apply_master" {
   project_name  = aws_codebuild_project.apply_master.name
-  branch_filter = "^master$"
+
+  filter_group {
+    filter {
+      type = "EVENT"
+      pattern = "PUSH, PULL_REQUEST_CREATED, PULL_REQUEST_UPDATED"
+    }
+
+    filter {
+      type = "HEAD_REF"
+      pattern = "^refs/heads/master$"
+    }
+  }
 
   // We use a provisioner here to remove the pull_request event from the apply
   // webhook.  Otherwise, this codebuild job will run for every PR.


### PR DESCRIPTION
The branch_filter argument won't work in terraform anymore - AWS seems to be deprecating it.

I believe this matches what we had written. I believe there are improvements we could make, but since we are trying to fix something that's currently broken, maybe we can revisit that in the future. The improvements are:

- I believe we can replace the negative lookahead `(?!master|develop)` with the pattern `^refs/heads/(?master|develop)$` and set the `exclude_matched_pattern` argument to `true`. I am not actually sure the current `^refs/heads/(?!master|develop).*$` will match the `^(?!master|develop).*$` exactly - I think it will, but I always found negative lookahead difficult to reason about.
- The `apply_develop` and `apply_master` webhooks contain the following lines:
    ```terraform
  // We use a provisioner here to remove the pull_request event from the apply
  // webhook.  Otherwise, this codebuild job will run for every PR.
  provisioner "local-exec" {
      command = "${path.module}/src/disable-webhook-pr.sh \"${aws_codebuild_webhook.apply_develop.url}\" \"${var.oauth_token}\""
  }
  ```
  I am not really sure I understand what this is doing (or why), but I think we could tweak the EVENT pattern to get the same effect?

I am also wondering about tags - do any of these pipelines currently run for tags? What does branch_filter do in that case? Because filtering on `refs/heads` won't ever match a tag. I guess our tagged repos usually don't use CodeBuild, so maybe it isn't a problem.