### PR TITLE
DP-26801: Add support for S3 alias records to the Route53 scanner.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.40] - 2023-02-09
+
+- [Entrypoint Monitor] Add support for S3 alias records to the Route53 scanner.
+
 ## [1.0.39] - 2023-02-02
 
 - [Pipelines] - Switch from `branch_filter` to `filter_group`.

--- a/entrypoint-monitoring/lambda/src/lib/scanner/Route53Scanner.ts
+++ b/entrypoint-monitoring/lambda/src/lib/scanner/Route53Scanner.ts
@@ -1,4 +1,5 @@
 import {
+  AliasTarget,
   HostedZone,
   ListHostedZonesCommand,
   ListHostedZonesCommandInput,
@@ -45,6 +46,12 @@ export default class Route53Scanner extends BaseScanner implements Scanner {
   protected async doScan(interconnections: Interconnections) {
     this.logger.log('==== Scanning Route53 Record Sets... ====')
 
+    const region = await this.client.config.region()
+    const s3AliasTargets = [
+      `s3-website.${region}.amazonaws.com`,
+      `s3-website-${region}.amazonaws.com`,
+    ]
+
     for await (const zone of this.getHostedZones()) {
       if (!zone.Id) {
         this.logger.error(`Zone without ID!`);
@@ -78,17 +85,12 @@ export default class Route53Scanner extends BaseScanner implements Scanner {
 
         this.logger.debug(`-- Record set ${recordSet.Name} `)
         if (recordSet.AliasTarget) {
-          if (recordSet.AliasTarget.DNSName === undefined) {
-            this.logger.error(`Route53 record set without an alias DNS name!`)
-            continue;
-          }
-
-          interconnections.addServiceToPointLink(
-            this.serviceType,
+          this.addAliasLink({
+            interconnections,
             serviceId,
-            this.normalizeDomainName(recordSet.AliasTarget.DNSName)
-          )
-          this.logger.debug(`- ${recordSet.AliasTarget.DNSName}`)
+            aliasTarget: recordSet.AliasTarget,
+            s3AliasTargets
+          })
         }
         else if (recordSet.ResourceRecords) {
           for (const record of recordSet.ResourceRecords) {
@@ -118,6 +120,51 @@ export default class Route53Scanner extends BaseScanner implements Scanner {
     }
 
     this.logger.log('==== The Route53 Record Sets scan is complete. ====')
+  }
+
+  addAliasLink({
+    interconnections,
+    serviceId,
+    aliasTarget,
+    s3AliasTargets
+  }: {
+    interconnections: Interconnections,
+    serviceId: string,
+    aliasTarget: AliasTarget,
+    s3AliasTargets: string[]
+  }): void {
+    if (aliasTarget.DNSName === undefined) {
+      this.logger.error(`Route53 record set without an alias DNS name!`)
+      return;
+    }
+
+    const normalizedTargetDnsName = this.normalizeDomainName(aliasTarget.DNSName)
+
+    // Route53 allows directly pointing to S3 Website endpoints. API shows it as
+    // an alias record pointing to a website endpoint but without the bucket
+    // prefix. We add `bucket.` prefix to them in order to match S3 website
+    // endpoints discovered by the S3 scanner.
+    for (const s3Target of s3AliasTargets) {
+      if (normalizedTargetDnsName === s3Target) {
+        const s3BucketEndpoint = `${this.normalizeDomainName(serviceId)}.${s3Target}`
+
+        interconnections.addServiceToPointLink(
+          this.serviceType,
+          serviceId,
+          s3BucketEndpoint
+        )
+        this.logger.debug(`- S3 website: ${s3BucketEndpoint}`)
+        return;
+      }
+    }
+
+    // Fallback to simply adding the alias target.
+    interconnections.addServiceToPointLink(
+      this.serviceType,
+      serviceId,
+      normalizedTargetDnsName
+    )
+    this.logger.debug(`- ${normalizedTargetDnsName}`)
   }
 
   async* getHostedZones(): AsyncGenerator<HostedZone> {

--- a/entrypoint-monitoring/lambda/src/lib/scanner/Route53Scanner.ts
+++ b/entrypoint-monitoring/lambda/src/lib/scanner/Route53Scanner.ts
@@ -101,7 +101,7 @@ export default class Route53Scanner extends BaseScanner implements Scanner {
 
             // Ignore the certificate validation records.
             if (recordSet.Type === 'CNAME' && this.ignoredCnameTarget.test(record.Value)) {
-              this.logger.debug(`---- Ignoring a special CNAME record: ${record.Value}`)
+              this.logger.debug(`--- Ignoring a special CNAME record: ${record.Value}`)
               continue;
             }
 
@@ -110,7 +110,7 @@ export default class Route53Scanner extends BaseScanner implements Scanner {
               serviceId,
               this.normalizeDomainName(record.Value)
             )
-            this.logger.debug(`---- ${record.Value}`);
+            this.logger.debug(`--- ${record.Value}`);
           }
         }
         else {
@@ -153,7 +153,7 @@ export default class Route53Scanner extends BaseScanner implements Scanner {
           serviceId,
           s3BucketEndpoint
         )
-        this.logger.debug(`- S3 website: ${s3BucketEndpoint}`)
+        this.logger.debug(`--- S3 website: ${s3BucketEndpoint}`)
         return;
       }
     }
@@ -164,7 +164,7 @@ export default class Route53Scanner extends BaseScanner implements Scanner {
       serviceId,
       normalizedTargetDnsName
     )
-    this.logger.debug(`- ${normalizedTargetDnsName}`)
+    this.logger.debug(`--- ${normalizedTargetDnsName}`)
   }
 
   async* getHostedZones(): AsyncGenerator<HostedZone> {


### PR DESCRIPTION
Just as a reminder, `lambda.js` is a transpilation result, so we expect to see changes from other files in this one.

Changes:
* Properly support for Route53 record -> S3 Website alias records. Such records don't have the bucket name as I expected before, so they require some special handling.
* Fix minor indentation issues with the debug log of the Route53 scanner.