### PR TITLE
Update teamsalerts module to not use unsupported terraform feature

### DIFF
--- a/teamsalerts/variables.tf
+++ b/teamsalerts/variables.tf
@@ -43,8 +43,4 @@ variable "topic_map" {
     human_name = string
     icon_url   = string
   }))
-  validation {
-    condition     = length(var.topic_map) > 0
-    error_message = "Topic map must specify at least one SNS topic to subscribe to."
-  }
 }


### PR DESCRIPTION
Fast-follow from this: https://github.com/massgov/mds-terraform-common/pull/93

Parameter validation isn't supported in the version of the terraform CLI we use to deploy ds-infra

Error in codebuild: https://us-east-1.console.aws.amazon.com/codesuite/codebuild/748039698304/projects/Infrastructure-plan/build/Infrastructure-plan%3Af1315654-4236-48b9-b679-281cc65e2a7d/?region=us-east-1