### PR TITLE
DP-27416: upgrade terraform modules to 0.13

### DIFF
--- a/asg/versions.tf
+++ b/asg/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/chamberpolicy/main.tf
+++ b/chamberpolicy/main.tf
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "readwrite_policy" {
       "ssm:DeleteParameter",
       "ssm:DeleteParameters",
     ]
-    resources = ["${local.namespace_parameters_arn}"]
+    resources = [local.namespace_parameters_arn]
   }
 
   // Read (decrypt)

--- a/chamberpolicy/versions.tf
+++ b/chamberpolicy/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/cloudfront_geo_restriction/versions.tf
+++ b/cloudfront_geo_restriction/versions.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/developerpolicy/versions.tf
+++ b/developerpolicy/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/domain-certificate/versions.tf
+++ b/domain-certificate/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.13"
 
   required_providers {
     aws = {

--- a/domain/versions.tf
+++ b/domain/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/ecscluster/versions.tf
+++ b/ecscluster/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
 }

--- a/entrypoint-monitoring/main.tf
+++ b/entrypoint-monitoring/main.tf
@@ -58,7 +58,8 @@ data "aws_iam_policy_document" "monitor_inline_policy" {
 }
 
 module "monitor_lambda" {
-  source                 = "github.com/massgov/mds-terraform-common//lambda?ref=1.0.26"
+  # TODO: change branch to tag before deploying
+  source                 = "github.com/massgov/mds-terraform-common//lambda?ref=DP-27416-terraform-upgrade-0.13"
   package                = data.archive_file.monitor_package.output_path
   runtime                = "nodejs12.x"
   handler                = "lambda.default"

--- a/entrypoint-monitoring/versions.tf
+++ b/entrypoint-monitoring/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 
   required_providers {
     aws = {

--- a/lambda/versions.tf
+++ b/lambda/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/lambda/versions.tf
+++ b/lambda/versions.tf
@@ -4,6 +4,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = ">= 4.8.0"
     }
   }
 }

--- a/pipelines/pipeline/main.tf
+++ b/pipelines/pipeline/main.tf
@@ -1,8 +1,8 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 locals {
-  region = "${coalesce(var.region, data.aws_region.current.name)}"
-  account_id = "${coalesce(var.account_id, data.aws_caller_identity.current.account_id)}"
+  region = coalesce(var.region, data.aws_region.current.name)
+  account_id = coalesce(var.account_id, data.aws_caller_identity.current.account_id)
   secrets_namespace = "tf/${var.namespace}"
 }
 

--- a/pipelines/pipeline/variables.tf
+++ b/pipelines/pipeline/variables.tf
@@ -39,13 +39,13 @@ variable "failure_topics" {
 }
 
 variable "region" {
-  type = "string"
+  type = string
   description = "The AWS region to scope access to (defaults to current region)."
   default = ""
 }
 
 variable "account_id" {
-  type = "string"
+  type = string
   description = "The AWS account ID to scope access to (defaults to current account)."
   default = ""
 }

--- a/pipelines/pipeline/versions.tf
+++ b/pipelines/pipeline/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/pipelines/roles/versions.tf
+++ b/pipelines/roles/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/rdsinstance/versions.tf
+++ b/rdsinstance/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/slackalerts/versions.tf
+++ b/slackalerts/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/static-site/iam.tf
+++ b/static-site/iam.tf
@@ -30,6 +30,6 @@ resource "aws_iam_group" "deployment" {
 }
 resource "aws_iam_group_policy" "deployment" {
   count = var.create_deployment_group ? 1 : 0
-  group = "${aws_iam_group.deployment[0].name}"
-  policy = "${data.aws_iam_policy_document.deployment.json}"
+  group = aws_iam_group.deployment[0].name
+  policy = data.aws_iam_policy_document.deployment.json
 }

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -4,11 +4,11 @@ provider "aws" {
 }
 
 variable "name" {
-  type = "string"
+  type = string
 }
 
 variable "bucket_name" {
-  type = "string"
+  type = string
   default = null
 }
 

--- a/static-site/versions.tf
+++ b/static-site/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/teamsalerts/main.tf
+++ b/teamsalerts/main.tf
@@ -1,5 +1,6 @@
 module "sns_to_teams" {
-  source  = "github.com/massgov/mds-terraform-common//lambda?ref=1.0.26"
+  # TODO: change branch to tag before deploying
+  source  = "github.com/massgov/mds-terraform-common//lambda?ref=DP-27416-terraform-upgrade-0.13"
   package = "${path.module}/lambda/dist/archive.zip"
   runtime = "nodejs12.x"
   handler = "lambda.handler"

--- a/teamsalerts/versions.tf
+++ b/teamsalerts/versions.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/vpcread/versions.tf
+++ b/vpcread/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/webhook-converters/github-to-teams/versions.tf
+++ b/webhook-converters/github-to-teams/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 
   required_providers {
     aws = {
@@ -10,6 +10,9 @@ terraform {
     archive = {
       source  = "hashicorp/archive"
       version = "~> 2.0"
+    }
+    random = {
+      source = "hashicorp/random"
     }
   }
 }


### PR DESCRIPTION
This is a draft PR for upgrading all terraform modules to use version 0.13. 

(the rest of this message is just a mirror of the Jira ticket update)

Upgrading the modules was pretty simple. I went through https://developer.hashicorp.com/terraform/language/v1.1.x/upgrade-guides/0-13 and https://github.com/hashicorp/terraform/blob/v0.13/CHANGELOG.md but honestly there didn’t seem to be anything that would affect us.

I also updated some old syntax that threw some warnings whenever terraform was run - simple things like replacing `"${resource_type.thing.arn}"` with `resource_type.thing.arn` and replacing types like `"string"` with `string`.

The upgrade documentation states multiple times that it’s best to deploy this with no other changes - so no resources added, removed, or modified. For that reason, I am wondering if we want to start a `2.x` branch and start tagging 0.13 versions with `2.whatever` instead? Or we could use `1.1.x` and `1.1.whatever` instead. My reasoning is that if we want to deploy this with no other changes, we will first have to update a site to `1.0.42` (or whatever the most recent version is when we do this). Then we will have to deploy this version. And then we can use any later versions. And our sites are not going to be updated overnight, so putting this on a `1.0.x` tag would block using any later tag versions until a repo was updated.

This would mean we would have to maintain a `1.x` and a `2.x` at the same time until everything was updated, but honestly that doesn’t seem like a huge deal - looking at the tag history, it seems like its mostly 1 or 2 tags per month, so we don’t update this a ton.