### PR TITLE
DP-26413: Add terraform aws provider minimum version constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## [1.0.43] - 2023-03-15
+
+- [ALL] Upgrade all modules to require terraform 0.13.
+- [ALL] Add minimum provider version constraints to all modules.
+
 ## [1.0.42] - 2023-03-03
 
 - [SNS to Teams] Add a module for subscribing Microsoft Teams incoming webhooks to SNS topics.

--- a/asg/versions.tf
+++ b/asg/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/asg/versions.tf
+++ b/asg/versions.tf
@@ -4,6 +4,9 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      # This may work with earlier versions, however the lowest version
+      # we have currently using it is 2.70.
+      version = ">= 2.70"
     }
   }
 }

--- a/chamberpolicy/main.tf
+++ b/chamberpolicy/main.tf
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "readwrite_policy" {
       "ssm:DeleteParameter",
       "ssm:DeleteParameters",
     ]
-    resources = ["${local.namespace_parameters_arn}"]
+    resources = [local.namespace_parameters_arn]
   }
 
   // Read (decrypt)

--- a/chamberpolicy/versions.tf
+++ b/chamberpolicy/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/chamberpolicy/versions.tf
+++ b/chamberpolicy/versions.tf
@@ -4,6 +4,9 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      # This may work with earlier versions, however the lowest version
+      # we have currently using it is 2.70.
+      version = ">= 2.70"
     }
   }
 }

--- a/cloudfront_geo_restriction/versions.tf
+++ b/cloudfront_geo_restriction/versions.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/cloudfront_geo_restriction/versions.tf
+++ b/cloudfront_geo_restriction/versions.tf
@@ -3,6 +3,9 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      # This may work with earlier versions, however the lowest version
+      # we have currently using it is 2.70.
+      version = ">= 2.70"
     }
   }
 }

--- a/developerpolicy/versions.tf
+++ b/developerpolicy/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/developerpolicy/versions.tf
+++ b/developerpolicy/versions.tf
@@ -4,6 +4,9 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      # This may work with earlier versions, however the lowest version
+      # we have currently using it is 2.70.
+      version = ">= 2.70"
     }
   }
 }

--- a/domain-certificate/versions.tf
+++ b/domain-certificate/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = ">= 3.0"
     }
   }
 }

--- a/domain-certificate/versions.tf
+++ b/domain-certificate/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.13"
 
   required_providers {
     aws = {

--- a/domain/versions.tf
+++ b/domain/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/ecscluster/versions.tf
+++ b/ecscluster/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
 }

--- a/ecscluster/versions.tf
+++ b/ecscluster/versions.tf
@@ -4,9 +4,15 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      # This may work with earlier versions, however the lowest version
+      # we have currently using it is 2.70.
+      version = ">= 2.70"
     }
     template = {
       source = "hashicorp/template"
+      # This may work with earlier versions, however the lowest version
+      # we have currently using it is 2.2.0.
+      version = ">= 2.2.0"
     }
   }
 }

--- a/entrypoint-monitoring/main.tf
+++ b/entrypoint-monitoring/main.tf
@@ -59,7 +59,7 @@ data "aws_iam_policy_document" "monitor_inline_policy" {
 
 module "monitor_lambda" {
   # TODO: change branch to tag before deploying
-  source                 = "github.com/massgov/mds-terraform-common//lambda?ref=DP-27416-terraform-upgrade-0.13"
+  source                 = "github.com/massgov/mds-terraform-common//lambda?ref=1.0.43"
   package                = data.archive_file.monitor_package.output_path
   runtime                = "nodejs12.x"
   handler                = "lambda.default"

--- a/entrypoint-monitoring/main.tf
+++ b/entrypoint-monitoring/main.tf
@@ -58,7 +58,8 @@ data "aws_iam_policy_document" "monitor_inline_policy" {
 }
 
 module "monitor_lambda" {
-  source                 = "github.com/massgov/mds-terraform-common//lambda?ref=1.0.26"
+  # TODO: change branch to tag before deploying
+  source                 = "github.com/massgov/mds-terraform-common//lambda?ref=DP-27416-terraform-upgrade-0.13"
   package                = data.archive_file.monitor_package.output_path
   runtime                = "nodejs12.x"
   handler                = "lambda.default"

--- a/entrypoint-monitoring/versions.tf
+++ b/entrypoint-monitoring/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 
   required_providers {
     aws = {

--- a/entrypoint-monitoring/versions.tf
+++ b/entrypoint-monitoring/versions.tf
@@ -5,11 +5,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.0"
+      version = ">= 2.0"
     }
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 2.0"
+      version = ">= 2.0"
     }
   }
 }

--- a/entrypoint-monitoring/versions.tf
+++ b/entrypoint-monitoring/versions.tf
@@ -5,7 +5,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      # Needed for lambda module
+      version = ">= 4.8.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/lambda/versions.tf
+++ b/lambda/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/lambda/versions.tf
+++ b/lambda/versions.tf
@@ -4,6 +4,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = ">= 4.8.0"
     }
   }
 }

--- a/pipelines/pipeline/main.tf
+++ b/pipelines/pipeline/main.tf
@@ -1,8 +1,8 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 locals {
-  region = "${coalesce(var.region, data.aws_region.current.name)}"
-  account_id = "${coalesce(var.account_id, data.aws_caller_identity.current.account_id)}"
+  region = coalesce(var.region, data.aws_region.current.name)
+  account_id = coalesce(var.account_id, data.aws_caller_identity.current.account_id)
   secrets_namespace = "tf/${var.namespace}"
 }
 

--- a/pipelines/pipeline/variables.tf
+++ b/pipelines/pipeline/variables.tf
@@ -39,13 +39,13 @@ variable "failure_topics" {
 }
 
 variable "region" {
-  type = "string"
+  type = string
   description = "The AWS region to scope access to (defaults to current region)."
   default = ""
 }
 
 variable "account_id" {
-  type = "string"
+  type = string
   description = "The AWS account ID to scope access to (defaults to current account)."
   default = ""
 }

--- a/pipelines/pipeline/versions.tf
+++ b/pipelines/pipeline/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/pipelines/pipeline/versions.tf
+++ b/pipelines/pipeline/versions.tf
@@ -4,6 +4,9 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      # This may work with earlier versions, however the lowest version
+      # we have currently using it is 2.70.
+      version = ">= 2.70"
     }
   }
 }

--- a/pipelines/roles/versions.tf
+++ b/pipelines/roles/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/pipelines/roles/versions.tf
+++ b/pipelines/roles/versions.tf
@@ -4,6 +4,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = ">= 2.70"
     }
   }
 }

--- a/rdsinstance/versions.tf
+++ b/rdsinstance/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/rdsinstance/versions.tf
+++ b/rdsinstance/versions.tf
@@ -4,6 +4,9 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      # This may work with earlier versions, however the lowest version
+      # we have currently using it is 2.70.
+      version = ">= 2.70"
     }
   }
 }

--- a/slackalerts/versions.tf
+++ b/slackalerts/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/slackalerts/versions.tf
+++ b/slackalerts/versions.tf
@@ -4,6 +4,9 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      # This may work with earlier versions, however the lowest version
+      # we have currently using it is 2.70.
+      version = ">= 2.70"
     }
   }
 }

--- a/static-site/iam.tf
+++ b/static-site/iam.tf
@@ -30,6 +30,6 @@ resource "aws_iam_group" "deployment" {
 }
 resource "aws_iam_group_policy" "deployment" {
   count = var.create_deployment_group ? 1 : 0
-  group = "${aws_iam_group.deployment[0].name}"
-  policy = "${data.aws_iam_policy_document.deployment.json}"
+  group = aws_iam_group.deployment[0].name
+  policy = data.aws_iam_policy_document.deployment.json
 }

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -4,11 +4,11 @@ provider "aws" {
 }
 
 variable "name" {
-  type = "string"
+  type = string
 }
 
 variable "bucket_name" {
-  type = "string"
+  type = string
   default = null
 }
 

--- a/static-site/versions.tf
+++ b/static-site/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/static-site/versions.tf
+++ b/static-site/versions.tf
@@ -4,6 +4,9 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      # This may work with earlier versions, however the lowest version
+      # we have currently using it is 2.70.
+      version = ">= 2.70"
     }
   }
 }

--- a/teamsalerts/main.tf
+++ b/teamsalerts/main.tf
@@ -1,5 +1,6 @@
 module "sns_to_teams" {
-  source  = "github.com/massgov/mds-terraform-common//lambda?ref=1.0.26"
+  # TODO: change branch to tag before deploying
+  source  = "github.com/massgov/mds-terraform-common//lambda?ref=DP-27416-terraform-upgrade-0.13"
   package = "${path.module}/lambda/dist/archive.zip"
   runtime = "nodejs12.x"
   handler = "lambda.handler"

--- a/teamsalerts/main.tf
+++ b/teamsalerts/main.tf
@@ -1,6 +1,6 @@
 module "sns_to_teams" {
   # TODO: change branch to tag before deploying
-  source  = "github.com/massgov/mds-terraform-common//lambda?ref=DP-27416-terraform-upgrade-0.13"
+  source  = "github.com/massgov/mds-terraform-common//lambda?ref=1.0.43"
   package = "${path.module}/lambda/dist/archive.zip"
   runtime = "nodejs12.x"
   handler = "lambda.handler"

--- a/teamsalerts/versions.tf
+++ b/teamsalerts/versions.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/teamsalerts/versions.tf
+++ b/teamsalerts/versions.tf
@@ -3,6 +3,9 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      # This may work with earlier versions, however the lowest version
+      # we have currently using it is 2.70.
+      version = ">= 2.70"
     }
   }
 }

--- a/teamsalerts/versions.tf
+++ b/teamsalerts/versions.tf
@@ -3,9 +3,8 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      # This may work with earlier versions, however the lowest version
-      # we have currently using it is 2.70.
-      version = ">= 2.70"
+      # Needed for lambda module
+      version = ">= 4.8.0"
     }
   }
 }

--- a/vpcread/versions.tf
+++ b/vpcread/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }

--- a/vpcread/versions.tf
+++ b/vpcread/versions.tf
@@ -4,6 +4,9 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      # This may work with earlier versions, however the lowest version
+      # we have currently using it is 2.70.
+      version = ">= 2.70"
     }
   }
 }

--- a/webhook-converters/github-to-teams/main.tf
+++ b/webhook-converters/github-to-teams/main.tf
@@ -31,7 +31,7 @@ resource "random_password" "path_token" {
 }
 
 module "lambda" {
-  source  = "github.com/massgov/mds-terraform-common//lambda?ref=DP-27416-terraform-upgrade-0.13"
+  source  = "github.com/massgov/mds-terraform-common//lambda?ref=1.0.43"
   package = data.archive_file.lambda_package.output_path
   runtime = "nodejs12.x"
   handler = "lambda.default"

--- a/webhook-converters/github-to-teams/main.tf
+++ b/webhook-converters/github-to-teams/main.tf
@@ -31,7 +31,7 @@ resource "random_password" "path_token" {
 }
 
 module "lambda" {
-  source  = "github.com/massgov/mds-terraform-common//lambda?ref=1.0.26"
+  source  = "github.com/massgov/mds-terraform-common//lambda?ref=DP-27416-terraform-upgrade-0.13"
   package = data.archive_file.lambda_package.output_path
   runtime = "nodejs12.x"
   handler = "lambda.default"

--- a/webhook-converters/github-to-teams/versions.tf
+++ b/webhook-converters/github-to-teams/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 
   required_providers {
     aws = {
@@ -10,6 +10,9 @@ terraform {
     archive = {
       source  = "hashicorp/archive"
       version = "~> 2.0"
+    }
+    random = {
+      source = "hashicorp/random"
     }
   }
 }

--- a/webhook-converters/github-to-teams/versions.tf
+++ b/webhook-converters/github-to-teams/versions.tf
@@ -5,14 +5,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.0"
+      version = ">= 2.0"
     }
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 2.0"
+      version = ">= 2.0"
     }
     random = {
       source = "hashicorp/random"
+      version = ">= 3.4"
     }
   }
 }

--- a/webhook-converters/github-to-teams/versions.tf
+++ b/webhook-converters/github-to-teams/versions.tf
@@ -5,7 +5,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      # Needed for lambda module
+      version = ">= 4.8.0"
     }
     archive = {
       source  = "hashicorp/archive"


### PR DESCRIPTION
This is based off the 0.13 upgrade branch. We can merge them together?