### PR TITLE
DP-27416: static site upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+
+## [1.0.45] - 2023-03-16
+
+- [Domain] Fix static-site module for hashicorp/aws versions >= 3.
+
+## [1.0.44] - 2023-03-15
+
+- [Domain] Fix domain module for hashicorp/aws versions >= 3.
+
 ## [1.0.43] - 2023-03-15
 
 - [ALL] Upgrade all modules to require terraform 0.13.

--- a/static-site/versions.tf
+++ b/static-site/versions.tf
@@ -4,9 +4,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      # This may work with earlier versions, however the lowest version
-      # we have currently using it is 2.70.
-      version = ">= 2.70"
+      version = ">= 3"
     }
   }
 }


### PR DESCRIPTION
The static-site module is broken in versions of hashicorp/aws >= 3.0 because `aws_acm_certificate.domain_validation_options` changed from a list to a set. This fixes the module to work with the upgraded version.