### PR TITLE
DP-26720: remove static-site module aws provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.48] - 2023-04-18
+
+ - [Static Site] Remove AWS provider from module.
+
 ## [1.0.47] - 2023-03-28
 
  - [Github to Teams] Upgrade to node16 runtime

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -1,8 +1,3 @@
-// aws region
-provider "aws" {
-  region = "us-east-1"
-}
-
 variable "name" {
   type = string
 }


### PR DESCRIPTION
I am having trouble removing the `unemployment` static site from DS-Infrastructure because the module declares some aws provider settings.

According to the terraform documentation [here:](https://developer.hashicorp.com/terraform/language/modules/develop/providers#implicit-provider-inheritance)

> As a consequence, you must ensure that all resources that belong to a particular provider configuration are destroyed before you can remove that provider configuration's block from your configuration. If Terraform finds a resource instance tracked in the state whose provider configuration block is no longer available then it will return an error during planning, prompting you to reintroduce the provider configuration.

The documentation also says (I bolded the important part):

> **A module intended to be called by one or more other modules must not contain any provider blocks.** A module containing its own provider configurations is not compatible with the for_each, count, and depends_on arguments that were introduced in Terraform v0.13.

It's possible this could cause issues with other uses of this module, but it is definitely considered a "legacy" feature and not a best practice. It should also be a very easy fix to add in the region in the module using this one.