### PR TITLE
Implement geo restrictions as WAFv2 web ACL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.52] - 2023-05-03
+
+ - [CloudFront Geo-Restriction V2] Implements geo-fencing as a WAFv2 web ACL
+ - [Cloudfront] Add argument enabling users to attach WAF web ACL to distribution
+
 ## [1.0.51] - 2023-05-02
 
  - [RDS] Implemented manual snapshot backup/cleanup functionality

--- a/cloudfront_geo_restriction_v2/main.tf
+++ b/cloudfront_geo_restriction_v2/main.tf
@@ -20,7 +20,7 @@ resource "aws_wafv2_web_acl" "default" {
   }
 
   rule {
-    name     = "${name_prefix}-restrict-blocked-contries"
+    name     = "${var.name_prefix}-restrict-blocked-contries"
     priority = 1
 
     action {
@@ -42,7 +42,7 @@ resource "aws_wafv2_web_acl" "default" {
   tags = merge(
     var.tags,
     {
-      Name = "${name_prefix}-web-acl"
+      Name = "${var.name_prefix}-web-acl"
     }
   )
 

--- a/cloudfront_geo_restriction_v2/main.tf
+++ b/cloudfront_geo_restriction_v2/main.tf
@@ -7,7 +7,6 @@ resource "aws_wafv2_web_acl" "default" {
   name        = "${var.name_prefix}-web-acl"
   description = "Web ACL that rejects requests to Cloudfront from blocked countries"
   scope       = "CLOUDFRONT"
-  capacity    = 1 // https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statements-list.html
 
   custom_response_body {
     key          = "custom-response-forbidden"

--- a/cloudfront_geo_restriction_v2/main.tf
+++ b/cloudfront_geo_restriction_v2/main.tf
@@ -19,7 +19,7 @@ resource "aws_wafv2_web_acl" "default" {
   }
 
   rule {
-    name     = "${var.name_prefix}-restrict-contries"
+    name     = "${var.name_prefix}-restrict-countries-rule"
     priority = 1
 
     action {
@@ -39,7 +39,7 @@ resource "aws_wafv2_web_acl" "default" {
 
     visibility_config {
       cloudwatch_metrics_enabled = var.enable_cloudwatch_metrics
-      metric_name                = "${var.name_prefix}-restrict-contries-metrics"
+      metric_name                = "${var.name_prefix}-restrict-countries-rule"
       sampled_requests_enabled   = false
     }
   }
@@ -53,7 +53,7 @@ resource "aws_wafv2_web_acl" "default" {
 
   visibility_config {
     cloudwatch_metrics_enabled = var.enable_cloudwatch_metrics
-    metric_name                = "${var.name_prefix}-web-acl-metrics"
+    metric_name                = "${var.name_prefix}-web-acl"
     sampled_requests_enabled   = false
   }
 }

--- a/cloudfront_geo_restriction_v2/main.tf
+++ b/cloudfront_geo_restriction_v2/main.tf
@@ -1,0 +1,54 @@
+module "cf_geo_restriction" {
+  source  = "github.com/massgov/mds-terraform-common//cloudfront_geo_restriction?ref=1.0.51"
+  enabled = var.geo_restriction
+}
+
+resource "aws_wafv2_web_acl" "default" {
+  name        = "${var.name_prefix}-web-acl"
+  description = "Web ACL that rejects requests to Cloudfront from blocked countries"
+  scope       = "CLOUDFRONT"
+  capacity    = 1 // https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statements-list.html
+
+  custom_response_body {
+    key          = "custom-response-forbidden"
+    content      = "Forbidden"
+    content_type = "TEXT_PLAIN"
+  }
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "${name_prefix}-restrict-blocked-contries"
+    priority = 1
+
+    action {
+      block {
+        custom_response {
+          response_code            = 403
+          custom_response_body_key = "custom-response-forbidden"
+        }
+      }
+    }
+
+    statement {
+      geo_match_statement {
+        country_codes = module.cf_geo_restriction.locations
+      }
+    }
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${name_prefix}-web-acl"
+    }
+  )
+
+  visibility_config {
+    cloudwatch_metrics_enabled = var.enable_cloudwatch_metrics
+    metric_name                = "${var.name_prefix}-web-acl-metrics"
+    sampled_requests_enabled   = false
+  }
+}

--- a/cloudfront_geo_restriction_v2/main.tf
+++ b/cloudfront_geo_restriction_v2/main.tf
@@ -19,7 +19,7 @@ resource "aws_wafv2_web_acl" "default" {
   }
 
   rule {
-    name     = "${var.name_prefix}-restrict-blocked-contries"
+    name     = "${var.name_prefix}-restrict-contries"
     priority = 1
 
     action {
@@ -39,7 +39,7 @@ resource "aws_wafv2_web_acl" "default" {
 
     visibility_config {
       cloudwatch_metrics_enabled = var.enable_cloudwatch_metrics
-      metric_name                = "${var.name_prefix}-restrict-blocked-countries-metrics"
+      metric_name                = "${var.name_prefix}-restrict-contries-metrics"
       sampled_requests_enabled   = false
     }
   }

--- a/cloudfront_geo_restriction_v2/main.tf
+++ b/cloudfront_geo_restriction_v2/main.tf
@@ -23,7 +23,7 @@ resource "aws_wafv2_web_acl" "default" {
     for_each = { for i, chunk in chunklist(module.cf_geo_restriction.locations, 50) : i => chunk }
     content {
       name     = "${var.name_prefix}-restrict-countries-rule-${rule.key}"
-      priority = 1
+      priority = tonumber(rule.key)
 
       action {
         block {

--- a/cloudfront_geo_restriction_v2/main.tf
+++ b/cloudfront_geo_restriction_v2/main.tf
@@ -36,6 +36,12 @@ resource "aws_wafv2_web_acl" "default" {
         country_codes = module.cf_geo_restriction.locations
       }
     }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = var.enable_cloudwatch_metrics
+      metric_name                = "${var.name_prefix}-restrict-blocked-countries-metrics"
+      sampled_requests_enabled   = false
+    }
   }
 
   tags = merge(

--- a/cloudfront_geo_restriction_v2/main.tf
+++ b/cloudfront_geo_restriction_v2/main.tf
@@ -1,6 +1,6 @@
 module "cf_geo_restriction" {
   source  = "github.com/massgov/mds-terraform-common//cloudfront_geo_restriction?ref=1.0.51"
-  enabled = var.geo_restriction
+  enabled = true
 }
 
 resource "aws_wafv2_web_acl" "default" {

--- a/cloudfront_geo_restriction_v2/outputs.tf
+++ b/cloudfront_geo_restriction_v2/outputs.tf
@@ -1,0 +1,3 @@
+output web_acl_arn {
+  value = aws_wafv2_web_acl.default.arn
+}

--- a/cloudfront_geo_restriction_v2/variables.tf
+++ b/cloudfront_geo_restriction_v2/variables.tf
@@ -1,0 +1,17 @@
+variable "name_prefix" {
+  type        = string
+  description = "A name prefix to use for created resources."
+}
+
+variable "enable_cloudwatch_metrics" {
+  type        = bool
+  description = "When true, WAF will report metrics (e.g. BlockedRequests) to Cloudwatch once per minute"
+  default = false
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Additional tags to apply to the WAF ACL"
+  default = {
+  }
+}

--- a/cloudfront_geo_restriction_v2/variables.tf
+++ b/cloudfront_geo_restriction_v2/variables.tf
@@ -1,6 +1,10 @@
 variable "name_prefix" {
   type        = string
   description = "A name prefix to use for created resources."
+  validation {
+    condition = can(regex("^[a-zA-Z0-9-]*[a-zA-Z0-9]+$", var.name_prefix))
+    error_message = "Prefix should only contain alphanumeric characters and (optionally) dashes. It must not end in a dash."
+  }
 }
 
 variable "enable_cloudwatch_metrics" {

--- a/cloudfront_geo_restriction_v2/versions.tf
+++ b/cloudfront_geo_restriction_v2/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = ">= 3.0.0"
+    }
+  }
+}

--- a/domain/main.tf
+++ b/domain/main.tf
@@ -97,6 +97,7 @@ resource "aws_cloudfront_distribution" "dashboards" {
   aliases         = [var.domain_name]
   is_ipv6_enabled = true
   comment         = var.comment
+  web_acl_id      = var.web_acl_id
 
   origin {
     domain_name = var.origin

--- a/domain/variables.tf
+++ b/domain/variables.tf
@@ -56,7 +56,13 @@ variable "tags" {
 }
 
 variable "geo_restriction" {
-  type = bool
-  default = true
+  type        = bool
+  default     = true
   description = "Enables geo-restriction of the CloudFront distribution."
+}
+
+variable "web_acl_id" {
+  type        = string
+  description = "Specifies the web ACL to apply to the distribution. For WAFv2, use the ACL ARN. Otherwise, use the ACL ID."
+  default     = null
 }


### PR DESCRIPTION
Adds a new module `cloudfront_geo_restrictions_v2`, which can be used to a create a web ACL forbidding requests to Cloudfront coming from blocked countries. The usage looks like
```tf
module web_acl_geo_fence {
  source                     = "github.com/massgov/mds-terraform-common//cloudfront_geo_restriction_v2?ref=1.0.52"
  name_prefix                = var.name_prefix
  enable_cloudwatch_metrics  = true
  tags                       = var.tags
}
# ...
resource "aws_cloudfront_distribution" "default" {
  enabled         = true
  web_acl_id      = module.web_acl_geo_fence.web_acl_arn
  # ...
}
```
Here's Karen demoing it with her VPN configured to put her computer in Hong Kong:
<img width="539" alt="MicrosoftTeams-image (2)" src="https://user-images.githubusercontent.com/12010279/236306850-e1bcc5ff-3ae5-4e30-8ab0-4372c01f04af.png">