### PR TITLE
DP-28599: Fix RDS snapshot cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.0.54] - 2023-06-23
+## [1.0.54] - 2023-06-26
 
  - [RDS] Fix monthly snapshot cleanup
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.54] - 2023-06-23
+
+ - [RDS] Fix monthly snapshot cleanup
+
 ## [1.0.53] - 2023-06-15
 
  - [ECS Cluster] Update module to use the Golden AMI by default.

--- a/rdsinstance/main.tf
+++ b/rdsinstance/main.tf
@@ -131,6 +131,14 @@ data "aws_iam_policy_document" "rds_snapshot_delete" {
     ]
     actions = [
       "rds:DescribeDBSnapshots",
+    ]
+  }
+  statement {
+    effect = "Allow"
+    resources = [
+      "arn:aws:rds:${data.aws_region.default.name}:${data.aws_caller_identity.default.account_id}:snapshot:${aws_db_instance.default.id}-*"
+    ]
+    actions = [
       "rds:DeleteDBSnapshot"
     ]
   }

--- a/rdsinstance/main.tf
+++ b/rdsinstance/main.tf
@@ -167,6 +167,7 @@ module "backup_lambda" {
       "Name" = "${aws_db_instance.default.id}-backup-lambda"
     }
   )
+  error_topics = var.backup_error_topics
 }
 
 module "cleanup_lambda" {
@@ -193,4 +194,5 @@ module "cleanup_lambda" {
       "Name" = "${aws_db_instance.default.id}-cleanup-lambda"
     }
   )
+  error_topics = var.backup_error_topics
 }

--- a/rdsinstance/main.tf
+++ b/rdsinstance/main.tf
@@ -136,7 +136,7 @@ data "aws_iam_policy_document" "rds_snapshot_delete" {
   statement {
     effect = "Allow"
     resources = [
-      "arn:aws:rds:${data.aws_region.default.name}:${data.aws_caller_identity.default.account_id}:snapshot:${aws_db_instance.default.id}-*"
+      "arn:aws:rds:${data.aws_region.default.name}:${data.aws_caller_identity.default.account_id}:snapshot:${aws_db_instance.default.id}*"
     ]
     actions = [
       "rds:DeleteDBSnapshot"

--- a/rdsinstance/main.tf
+++ b/rdsinstance/main.tf
@@ -129,7 +129,10 @@ data "aws_iam_policy_document" "rds_snapshot_delete" {
       "arn:aws:rds:${data.aws_region.default.name}:${data.aws_caller_identity.default.account_id}:snapshot:*",
       aws_db_instance.default.arn
     ]
-    actions = ["rds:DeleteDBSnapshot"]
+    actions = [
+      "rds:DescribeDBSnapshots",
+      "rds:DeleteDBSnapshot"
+    ]
   }
 }
 

--- a/rdsinstance/src/cleanup_lambda/index.ts
+++ b/rdsinstance/src/cleanup_lambda/index.ts
@@ -42,7 +42,7 @@ const handler: Handler<Event> = async (event: Event) => {
     (snapshots) => deleteSnapshots(dryRun, snapshots),
     tap(
       (deleteResult) => deleteResult?.DBSnapshot
-        ? console.log(`Successfully cleaned up ${deleteResult?.DBSnapshot}`)
+        ? console.log(`Successfully cleaned up ${deleteResult.DBSnapshot.DBSnapshotIdentifier}`)
         : undefined
     ),
     consume

--- a/rdsinstance/variables.tf
+++ b/rdsinstance/variables.tf
@@ -173,3 +173,9 @@ variable "manual_snapshot_schedule" {
   type        = map(string)
   default     = {}
 }
+
+variable "backup_error_topics" {
+  type        = list(string)
+  description = "An array of SNS topics to publish notifications to when backups error out"
+  default     = []
+}


### PR DESCRIPTION
We're seeing the following for itd-dv-lte-rawdata
```
{
    "errorType": "AccessDenied",
    "errorMessage": "User: arn:aws:sts::786775234217:assumed-role/itd-dv-lte-rawdata-cleanup-lambda/itd-dv-lte-rawdata-cleanup-lambda is not authorized to perform: rds:DescribeDBSnapshots on resource: arn:aws:rds:us-east-1:786775234217:db:itd-dv-lte-rawdata because no identity-based policy allows the rds:DescribeDBSnapshots action",
    "code": "AccessDenied",
    "message": "User: arn:aws:sts::786775234217:assumed-role/itd-dv-lte-rawdata-cleanup-lambda/itd-dv-lte-rawdata-cleanup-lambda is not authorized to perform: rds:DescribeDBSnapshots on resource: arn:aws:rds:us-east-1:786775234217:db:itd-dv-lte-rawdata because no identity-based policy allows the rds:DescribeDBSnapshots action",
    "time": "2023-06-05T23:00:32.392Z",
    "requestId": "9bb1e202-e52c-43b4-9f2e-fbc744dd1136",
    "statusCode": 403,
    "retryable": false,
    "retryDelay": 21.171784567754482,
    "stack": [
        "AccessDenied: User: arn:aws:sts::786775234217:assumed-role/itd-dv-lte-rawdata-cleanup-lambda/itd-dv-lte-rawdata-cleanup-lambda is not authorized to perform: rds:DescribeDBSnapshots on resource: arn:aws:rds:us-east-1:786775234217:db:itd-dv-lte-rawdata because no identity-based policy allows the rds:DescribeDBSnapshots action",
        "    at Request.extractError (/var/task/index.js:11100:33)",
        "    at Request.callListeners (/var/task/index.js:12159:24)",
        "    at Request.emit (/var/task/index.js:12134:14)",
        "    at Request.emit (/var/task/index.js:16808:18)",
        "    at Request.transition (/var/task/index.js:16414:15)",
        "    at AcceptorStateMachine.runTo (/var/task/index.js:14855:16)",
        "    at /var/task/index.js:14870:15",
        "    at Request.<anonymous> (/var/task/index.js:16430:13)",
        "    at Request.<anonymous> (/var/task/index.js:16811:16)",
        "    at Request.callListeners (/var/task/index.js:12169:22)"
    ]
}
```

`itd-dv-lte-rawdata` test results here: https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Flambda%2Fitd-dv-lte-rawdata-cleanup-lambda/log-events/2023%2F06%2F23%2F[%24LATEST]13fed47154a94a03b3c121c8e1975abd?start=PT3H