### PR TITLE
DP-28599: bad snapshot names

### DIFF
--- a/rdsinstance/src/backup_lambda/index.ts
+++ b/rdsinstance/src/backup_lambda/index.ts
@@ -20,7 +20,7 @@ const handler: Handler<Event> = async (event: Event) => {
 
   const dryRun = event.dryRun ?? false;
   const snapshotTimeStamp = LocalDateTime.now().format(
-    DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss")
+    DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss")
   );
   const instanceIds = [identifier];
 

--- a/rdsinstance/src/backup_lambda/index.ts
+++ b/rdsinstance/src/backup_lambda/index.ts
@@ -19,7 +19,9 @@ const handler: Handler<Event> = async (event: Event) => {
   );
 
   const dryRun = event.dryRun ?? false;
-  const snapshotTimeStamp = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+  const snapshotTimeStamp = LocalDateTime.now().format(
+    DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss")
+  );
   const instanceIds = [identifier];
 
   const params: Array<CreateDBSnapshotMessage> = instanceIds.map(


### PR DESCRIPTION
From AWS:
```
{
  "errorType": "InvalidParameterValue",
  "errorMessage": "The parameter DBSnapshotIdentifier is not a valid identifier. Identifiers must begin with a letter; must contain only ASCII letters, digits, and hyphens; and must not end with a hyphen or contain two consecutive hyphens.",
  "trace": [
    "InvalidParameterValue: The parameter DBSnapshotIdentifier is not a valid identifier. Identifiers must begin with a letter; must contain only ASCII letters, digits, and hyphens; and must not end with a hyphen or contain two consecutive hyphens.",
    "    at Request.extractError (/var/task/index.js:11100:33)",
    "    at Request.callListeners (/var/task/index.js:12159:24)",
    "    at Request.emit (/var/task/index.js:12134:14)",
    "    at Request.emit (/var/task/index.js:16808:18)",
    "    at Request.transition (/var/task/index.js:16414:15)",
    "    at AcceptorStateMachine.runTo (/var/task/index.js:14855:16)",
    "    at /var/task/index.js:14870:15",
    "    at Request.<anonymous> (/var/task/index.js:16430:13)",
    "    at Request.<anonymous> (/var/task/index.js:16811:16)",
    "    at Request.callListeners (/var/task/index.js:12169:22)"
  ]
}
```

ISO date strings have colons in them, which seems to be the issue, this fixes the formatter.