### PR TITLE
DP-28596: Allow setting delete_on_termination for AMI volumes

### DIFF
--- a/asg/main.tf
+++ b/asg/main.tf
@@ -21,6 +21,18 @@ resource "aws_launch_template" "default" {
     }
   }
 
+  dynamic "block_device_mappings" {
+    for_each = var.delete_on_termination_devices
+
+    content {
+      device_name = block_device_mappings.value
+
+      ebs {
+        delete_on_termination = "true"
+      }
+    }
+  }
+
   credit_specification {
     cpu_credits = "standard"
   }

--- a/asg/main.tf
+++ b/asg/main.tf
@@ -11,24 +11,20 @@ resource "aws_launch_template" "default" {
   user_data              = var.user_data
   ebs_optimized          = true
 
-  block_device_mappings {
-    device_name = "/dev/xvda"
-    ebs {
-      volume_size           = var.volume_size
-      volume_type           = "gp2"
-      delete_on_termination = "true"
-      encrypted             = var.volume_encryption
-    }
-  }
-
   dynamic "block_device_mappings" {
-    for_each = var.delete_on_termination_devices
+    for_each = var.block_devices
 
     content {
-      device_name = block_device_mappings.value
+      device_name = block_device_mappings.value.device_name
 
       ebs {
-        delete_on_termination = "true"
+        delete_on_termination = block_device_mappings.value.delete_on_termination
+        encrypted = block_device_mappings.value.encrypted
+        iops = block_device_mappings.value.iops
+        snapshot_id = block_device_mappings.value.snapshot_id
+        throughput = block_device_mappings.value.throughput
+        volume_size = block_device_mappings.value.volume_size
+        volume_type = block_device_mappings.value.volume_type
       }
     }
   }

--- a/asg/variables.tf
+++ b/asg/variables.tf
@@ -117,3 +117,9 @@ variable "tags" {
   }
 }
 
+variable "delete_on_termination_devices" {
+  type        = list(string)
+  description = "AMI devices for which to set the `delete_on_termination` setting to true."
+  default     = []
+}
+

--- a/asg/variables.tf
+++ b/asg/variables.tf
@@ -117,9 +117,28 @@ variable "tags" {
   }
 }
 
-variable "delete_on_termination_devices" {
-  type        = list(string)
-  description = "AMI devices for which to set the `delete_on_termination` setting to true."
-  default     = []
+variable "block_devices" {
+  type         = list(object({
+                   device_name = string,
+                   delete_on_termination = bool,
+                   encrypted = bool,
+                   iops = number,
+                   snapshot_id = string,
+                   throughput = number,
+                   volume_size = number,
+                   volume_type = string
+                 }))
+  description = "List of block_device_mappings for the launch template. See the `block_device_mappings` block in the aws_launch_template resource for descriptions of the fields."
+  default = [
+    {
+      device_name = "/dev/xvda",
+      delete_on_termination = true,
+      encrypted = true,
+      iops = null,
+      snapshot_id = null,
+      throughput = null,
+      volume_size = 30,
+      volume_type = "gp2"
+    }
+  ]
 }
-

--- a/ecscluster/variables.tf
+++ b/ecscluster/variables.tf
@@ -98,8 +98,13 @@ variable "ami" {
   default = ""
 }
 
-variable "delete_on_termination_devices" {
+variable "include_ami_device_names" {
   type        = list(string)
-  description = "AMI devices for which to set the `delete_on_termination` setting to true."
-  default     = []
+  description = "List of AMI devices for which to include in the `block_device_mappings`."
+}
+
+variable "ami_volumes_delete_on_termination" {
+  type        = bool
+  description = "Whether to set the `delete_on_termination` flag for volumes included from the AMI."
+  default     = true
 }

--- a/ecscluster/variables.tf
+++ b/ecscluster/variables.tf
@@ -98,3 +98,8 @@ variable "ami" {
   default = ""
 }
 
+variable "delete_on_termination_devices" {
+  type        = list(string)
+  description = "AMI devices for which to set the `delete_on_termination` setting to true."
+  default     = []
+}


### PR DESCRIPTION
This feels kind of clunky to me, but I don't see any other way to do it.

We need to specify the device names of the volumes that we want to override `delete_on_termination` for.

It may be less clunky to just remove the default golden ami part and make the user manually specify the ami and devices - which would still be somewhat clunky, but at least we could get rid of the logic of deciding whether to use the list specific to the golden ami or not.

I am really hoping that future versions of the golden ami still use the same device name for the mounted volume - otherwise, we have a whole new problem - although manually specifying the ami and volume would make this less confusing, as it would always be on the code instantiating the module to provide the correct values.