### PR TITLE
DP-28064: redo webhook filter groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.55] - 2023-07-12
+
+ - [Pipelines] Correct pipeline trigger issues
+
 ## [1.0.54] - 2023-06-26
 
  - [RDS] Fix monthly snapshot cleanup

--- a/pipelines/pipeline/main.tf
+++ b/pipelines/pipeline/main.tf
@@ -57,12 +57,24 @@ resource "aws_codebuild_webhook" "plan" {
   filter_group {
     filter {
       type = "EVENT"
-      pattern = "PUSH, PULL_REQUEST_CREATED, PULL_REQUEST_UPDATED"
+      pattern = "PULL_REQUEST_CREATED, PULL_REQUEST_UPDATED, PULL_REQUEST_REOPENED"
+    }
+
+    filter {
+      type = "BASE_REF"
+      pattern = "^refs/heads/(?:master|main|develop)$"
+    }
+  }
+
+  filter_group {
+    filter {
+      type = "EVENT"
+      pattern = "PUSH"
     }
 
     filter {
       type = "HEAD_REF"
-      pattern = "^refs/heads/(?:master|develop)$"
+      pattern = "^refs/heads/(?:master|main|develop)$"
       exclude_matched_pattern = true
     }
   }
@@ -74,7 +86,7 @@ resource "aws_codebuild_webhook" "apply_develop" {
   filter_group {
     filter {
       type = "EVENT"
-      pattern = "PUSH, PULL_REQUEST_CREATED, PULL_REQUEST_UPDATED"
+      pattern = "PUSH"
     }
 
     filter {
@@ -147,12 +159,12 @@ resource "aws_codebuild_webhook" "apply_master" {
   filter_group {
     filter {
       type = "EVENT"
-      pattern = "PUSH, PULL_REQUEST_CREATED, PULL_REQUEST_UPDATED"
+      pattern = "PUSH"
     }
 
     filter {
       type = "HEAD_REF"
-      pattern = "^refs/heads/master$"
+      pattern = "^refs/heads/(?:master|main)$"
     }
   }
 

--- a/pipelines/pipeline/main.tf
+++ b/pipelines/pipeline/main.tf
@@ -65,19 +65,6 @@ resource "aws_codebuild_webhook" "plan" {
       pattern = "^refs/heads/(?:master|main|develop)$"
     }
   }
-
-  filter_group {
-    filter {
-      type = "EVENT"
-      pattern = "PUSH"
-    }
-
-    filter {
-      type = "HEAD_REF"
-      pattern = "^refs/heads/(?:master|main|develop)$"
-      exclude_matched_pattern = true
-    }
-  }
 }
 
 resource "aws_codebuild_webhook" "apply_develop" {


### PR DESCRIPTION
### The Change
Rewires our codebuild webhook filter groups to implement the following logic:
```js
if (
  PR_to_dev_created
    || PR_to_dev_updated
    || PR_to_main_created
    || PR_to_main_updated
) {
  do_plan_yml()
} else if (
  PR_to_dev_merged || PR_to_main_merged
) { 
  do_apply_yml()
}
```

### Testing

I tested this with the [ssr-codebuild-test repo](https://github.com/massgov/ssr-codebuild-test) and everything worked as expected:

<img width="917" alt="Screen Shot 2023-07-12 at 12 32 38 PM" src="https://github.com/massgov/mds-terraform-common/assets/12010279/eb2e4532-dcee-4f5b-b339-1d1c4df5a629">
<hr />
<img width="917" alt="Screen Shot 2023-07-12 at 12 32 10 PM" src="https://github.com/massgov/mds-terraform-common/assets/12010279/d2ad16f0-e4be-44d0-a47b-66f0a641e4ee">

_Note that the dev -> main PR didn't rerun the dev apply; however, it was gated by the results_