### PR TITLE
DP-28596: Allow fixing unattached volumes error in ecscluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.56] - 2023-07-13
+
+ - [ASG] Replace `volume_encryption` and `volume_size` variables with `block_devices` variable
+ - [ECS Cluster] Add `include_ami_device_names` variable to allow importing block device specifications from AMI.
+ - [ECS Cluster] Add `ami_volumes_delete_on_termination` variable to allow forcing `delete_on_termination` to true on block devices imported from AMI.
+
 ## [1.0.55] - 2023-07-12
 
  - [Pipelines] Correct pipeline trigger issues

--- a/asg/main.tf
+++ b/asg/main.tf
@@ -21,6 +21,18 @@ resource "aws_launch_template" "default" {
     }
   }
 
+  dynamic "block_device_mappings" {
+    for_each = var.delete_on_termination_devices
+
+    content {
+      device_name = block_device_mappings.value
+
+      ebs {
+        delete_on_termination = "true"
+      }
+    }
+  }
+
   credit_specification {
     cpu_credits = "standard"
   }

--- a/asg/main.tf
+++ b/asg/main.tf
@@ -11,24 +11,20 @@ resource "aws_launch_template" "default" {
   user_data              = var.user_data
   ebs_optimized          = true
 
-  block_device_mappings {
-    device_name = "/dev/xvda"
-    ebs {
-      volume_size           = var.volume_size
-      volume_type           = "gp2"
-      delete_on_termination = "true"
-      encrypted             = var.volume_encryption
-    }
-  }
-
   dynamic "block_device_mappings" {
-    for_each = var.delete_on_termination_devices
+    for_each = var.block_devices
 
     content {
-      device_name = block_device_mappings.value
+      device_name = block_device_mappings.value.device_name
 
       ebs {
-        delete_on_termination = "true"
+        delete_on_termination = block_device_mappings.value.delete_on_termination
+        encrypted = block_device_mappings.value.encrypted
+        iops = block_device_mappings.value.iops
+        snapshot_id = block_device_mappings.value.snapshot_id
+        throughput = block_device_mappings.value.throughput
+        volume_size = block_device_mappings.value.volume_size
+        volume_type = block_device_mappings.value.volume_type
       }
     }
   }

--- a/asg/variables.tf
+++ b/asg/variables.tf
@@ -22,18 +22,6 @@ variable "instance_type" {
   default     = "t3.nano"
 }
 
-variable "volume_size" {
-  type        = string
-  description = "The EBS volume size to use for the root EBS volume"
-  default     = 30
-}
-
-variable "volume_encryption" {
-  type        = string
-  description = "A boolean indicating whether to encrypt the root EBS volume or not."
-  default     = false
-}
-
 variable "security_groups" {
   type        = list(string)
   description = "Security groups to apply to the instances."

--- a/asg/variables.tf
+++ b/asg/variables.tf
@@ -121,7 +121,7 @@ variable "block_devices" {
     {
       device_name = "/dev/xvda",
       delete_on_termination = true,
-      encrypted = true,
+      encrypted = false,
       iops = null,
       snapshot_id = null,
       throughput = null,

--- a/asg/variables.tf
+++ b/asg/variables.tf
@@ -117,3 +117,9 @@ variable "tags" {
   }
 }
 
+variable "delete_on_termination_devices" {
+  type        = list(string)
+  description = "AMI devices for which to set the `delete_on_termination` setting to true."
+  default     = []
+}
+

--- a/asg/variables.tf
+++ b/asg/variables.tf
@@ -117,9 +117,28 @@ variable "tags" {
   }
 }
 
-variable "delete_on_termination_devices" {
-  type        = list(string)
-  description = "AMI devices for which to set the `delete_on_termination` setting to true."
-  default     = []
+variable "block_devices" {
+  type         = list(object({
+                   device_name = string,
+                   delete_on_termination = bool,
+                   encrypted = bool,
+                   iops = number,
+                   snapshot_id = string,
+                   throughput = number,
+                   volume_size = number,
+                   volume_type = string
+                 }))
+  description = "List of block_device_mappings for the launch template. See the `block_device_mappings` block in the aws_launch_template resource for descriptions of the fields."
+  default = [
+    {
+      device_name = "/dev/xvda",
+      delete_on_termination = true,
+      encrypted = true,
+      iops = null,
+      snapshot_id = null,
+      throughput = null,
+      volume_size = 30,
+      volume_type = "gp2"
+    }
+  ]
 }
-

--- a/ecscluster/main.tf
+++ b/ecscluster/main.tf
@@ -1,3 +1,4 @@
+# Default AMI to use when none is specified.
 data "aws_ssm_parameter" "golden_ami_latest" {
   name = "/GoldenAMI/Linux/AWS2/latest"
 }

--- a/ecscluster/variables.tf
+++ b/ecscluster/variables.tf
@@ -98,8 +98,13 @@ variable "ami" {
   default = ""
 }
 
-variable "delete_on_termination_devices" {
+variable "include_ami_device_names" {
   type        = list(string)
-  description = "AMI devices for which to set the `delete_on_termination` setting to true."
-  default     = []
+  description = "List of AMI devices for which to include in the `block_device_mappings`."
+}
+
+variable "ami_volumes_delete_on_termination" {
+  type        = bool
+  description = "Whether to set the `delete_on_termination` flag for volumes included from the AMI."
+  default     = true
 }

--- a/ecscluster/variables.tf
+++ b/ecscluster/variables.tf
@@ -98,3 +98,8 @@ variable "ami" {
   default = ""
 }
 
+variable "delete_on_termination_devices" {
+  type        = list(string)
+  description = "AMI devices for which to set the `delete_on_termination` setting to true."
+  default     = []
+}


### PR DESCRIPTION
To actually fix this, we need to include a copy of the block device specification from the AMI with the `delete_on_termination` value set to true.

I tried before to override it by only setting the "device_name" and the "delete_on_termination" flag, but it didn't have any effect. It seems like at least some of the other fields have to be set for it to be recognized - otherwise the launch template just continues adding new volumes every time it starts (and never deleting them).

This led to 2 big changes.

### ASG:

- I removed the original hard-coded `block_device_mapping`. It was too awkward to have one hard-coded `block_device_mapping` and then allow other non-hard-coded `block_device_mapping`s to be provided.
- This meant the `volume_size` and `volume_encryption` variables were no longer useful. The user can specify these (and other values) directly in the `block_devices` variable.
- The default `block_devices` value is set to the values from the original hard-coded `block_device_mapping`.

### ECS Cluster

- The default `block_devices` is the previous default block device from the `asg` module.
- I added a variable `include_ami_device_names`. Any device names specified in this list will be copied into the `block_devices` variable supplied to the `asg` module. This variable has no default (so is required). This is unfortunate, but otherwise using this module with the default variables would result in the unattached volume bug.
- I added a variable `ami_volumes_delete_on_termination`. When this is set, any block devices copied from the `include_ami_device_names` variable will have `delete_on_termination` forced to `true`.
