### PR TITLE
DP-28166: split block device lookup into separate module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.57] - 2023-07-17
+
+ - [AMI Block Device Reader] Add a module to read and manipulate block devices from an AMI.
+ - [ECS Cluster] Replace block device lookup with new module.
+
 ## [1.0.56] - 2023-07-13
 
  - [ASG] Replace `volume_encryption` and `volume_size` variables with `block_devices` variable

--- a/ami-block-device-reader/README.md
+++ b/ami-block-device-reader/README.md
@@ -17,7 +17,7 @@ An example of using this module:
 ```terraform
 module "ami_devices" {
   source                      = "github.com/massgov/mds-terraform-common//aws-block-device-reader?ref=1.0.57"
-  ami                         = "my-ami123"
+  ami                         = "ami-12345"
 
   # Only include the "/dev/sdf" device
   device_filter_type          = "include"

--- a/ami-block-device-reader/README.md
+++ b/ami-block-device-reader/README.md
@@ -51,5 +51,7 @@ resource "aws_launch_template" "default" {
   }
 
   # ...
+}
+
 ```
 

--- a/ami-block-device-reader/README.md
+++ b/ami-block-device-reader/README.md
@@ -1,14 +1,14 @@
 AMI Block Device Reader
 ===============
 
-This module queries an AMI and outputs a subset of block devices defined by the AMI. Which devices are included in the output can be specified by the `device_filter_type`, `device_names`, and `exclude_root_device` variables.
+This module queries an AMI and outputs a (filtered) list of the block devices it defines. Which devices are included in the output can be specified by the `device_filter_type`, `device_names`, and `exclude_root_device` variables.
 
-- When `device_filter_type` is `include`, the output only contains the volumes whose names are in the `device_names` list.
+- When `device_filter_type` is `include`, the output only contains the devices whose names are in the `device_names` list.
 - When `device_filter_type` is `exclude`, the output contains all devices except:
   - Devices whose name is *not* in the `device_names` list.
   - The root device (if `exclude_root_device` is `true`).
 
-Additionally, if the `force_delete_on_termination` variable is set to `true`, the volumes will all have the `delete_on_termination` property set to `true`.
+Additionally, if the `force_delete_on_termination` variable is set to `true`, the devices will all have the `delete_on_termination` property set to `true`.
 
 
 
@@ -17,21 +17,21 @@ An example of using this module:
 ```terraform
 module "ami_devices" {
   source                      = "github.com/massgov/mds-terraform-common//aws-block-device-reader?ref=1.0.57"
-  ami                         = var.ami
+  ami                         = "my-ami123"
 
   # Only include the "/dev/sdf" device
   device_filter_type          = "include"
   include_device_names        = ["/dev/sdf"]
 
   # Set delete_on_termination to `true`.
-  force_delete_on_termination = var.ami_volumes_delete_on_termination
+  force_delete_on_termination = true
 }
 
 
 resource "aws_launch_template" "default" {
   # ...
 
-  # Redefine the volumes from the AMI in our launch template.
+  # Redefine the block devices from the AMI in our launch template.
   dynamic "block_device_mappings" {
     for_each = module.ami_devices.ami_devices
 

--- a/ami-block-device-reader/README.md
+++ b/ami-block-device-reader/README.md
@@ -1,0 +1,4 @@
+AMI Block Device Reader
+===============
+
+This module **reads** block devices from an AMI.  It allows filtering based on a list of device names, as well as overriding the `delete_on_termination` value in the results.

--- a/ami-block-device-reader/README.md
+++ b/ami-block-device-reader/README.md
@@ -33,7 +33,7 @@ resource "aws_launch_template" "default" {
 
   # Redefine the block devices from the AMI in our launch template.
   dynamic "block_device_mappings" {
-    for_each = module.ami_devices.ami_devices
+    for_each = module.ami_devices.block_devices
 
     content {
       device_name = block_device_mappings.value.device_name

--- a/ami-block-device-reader/README.md
+++ b/ami-block-device-reader/README.md
@@ -1,4 +1,55 @@
 AMI Block Device Reader
 ===============
 
-This module **reads** block devices from an AMI.  It allows filtering based on a list of device names, as well as overriding the `delete_on_termination` value in the results.
+This module queries an AMI and outputs a subset of block devices defined by the AMI. Which devices are included in the output can be specified by the `device_filter_type`, `device_names`, and `exclude_root_device` variables.
+
+- When `device_filter_type` is `include`, the output only contains the volumes whose names are in the `device_names` list.
+- When `device_filter_type` is `exclude`, the output contains all devices except:
+  - Devices whose name is *not* in the `device_names` list.
+  - The root device (if `exclude_root_device` is `true`).
+
+Additionally, if the `force_delete_on_termination` variable is set to `true`, the volumes will all have the `delete_on_termination` property set to `true`.
+
+
+
+An example of using this module:
+
+```terraform
+module "ami_devices" {
+  source                      = "github.com/massgov/mds-terraform-common//aws-block-device-reader?ref=1.0.57"
+  ami                         = var.ami
+
+  # Only include the "/dev/sdf" device
+  device_filter_type          = "include"
+  include_device_names        = ["/dev/sdf"]
+
+  # Set delete_on_termination to `true`.
+  force_delete_on_termination = var.ami_volumes_delete_on_termination
+}
+
+
+resource "aws_launch_template" "default" {
+  # ...
+
+  # Redefine the volumes from the AMI in our launch template.
+  dynamic "block_device_mappings" {
+    for_each = module.ami_devices.ami_devices
+
+    content {
+      device_name = block_device_mappings.value.device_name
+
+      ebs {
+        delete_on_termination = block_device_mappings.value.delete_on_termination
+        encrypted = block_device_mappings.value.encrypted
+        iops = block_device_mappings.value.iops
+        snapshot_id = block_device_mappings.value.snapshot_id
+        throughput = block_device_mappings.value.throughput
+        volume_size = block_device_mappings.value.volume_size
+        volume_type = block_device_mappings.value.volume_type
+      }
+    }
+  }
+
+  # ...
+```
+

--- a/ami-block-device-reader/main.tf
+++ b/ami-block-device-reader/main.tf
@@ -7,13 +7,13 @@ data "aws_ami" "default" {
 }
 
 locals {
-  exclude_root_list = var.exclude_root_device ? [data.aws_ami.default.root_device_name] : []
-  exclude_list = concat(local.exclude_root_list, var.exclude_device_names)
+  # If the filter type is `exclude` and `exclude_root_device` is set, add the root device name to the list
+  exclude_root_list = var.device_filter_type == "exclude" && var.exclude_root_device ? [data.aws_ami.default.root_device_name] : []
 
-  filter_list = var.device_filter_type == "include" ? var.include_device_names : local.exclude_list
+  filter_list = concat(local.exclude_root_list, var.device_names)
 
-  # If we're including, then `contains` should be true; for excluding, it should
-  # be false.
+  # If the filter type is `include`, then we want to include the volume only if it is contained in the list.
+  # If the filter type is `exclude`, then we want to include the volume only if it is NOT contained in the list.
   filter_contains_value = var.device_filter_type == "include" ? true : false
 
   block_devices = [

--- a/ami-block-device-reader/main.tf
+++ b/ami-block-device-reader/main.tf
@@ -1,0 +1,31 @@
+# Look up AMI for `include_ami_device_names`
+data "aws_ami" "default" {
+  filter {
+    name = "image-id"
+    values = [var.ami]
+  }
+}
+
+locals {
+  exclude_root_list = var.exclude_root_device ? [data.aws_ami.default.root_device_name] : []
+  exclude_list = concat(local.exclude_root_list, var.exclude_device_names)
+
+  filter_list = var.device_filter_type == "include" ? var.include_device_names : local.exclude_list
+
+  # If we're including, then `contains` should be true; for excluding, it should
+  # be false.
+  filter_contains_value = var.device_filter_type == "include" ? true : false
+
+  block_devices = [
+    for mapping in data.aws_ami.default.block_device_mappings :
+      # flatten object so there isn't a nested "ebs" object
+      merge(
+         {device_name = mapping.device_name},
+         mapping.ebs,
+         # overwrite delete_on_termination based on variable
+         var.force_delete_on_termination ? { delete_on_termination = true } : {}
+      )
+      # Only include devices that pass the filter.
+      if (contains(local.filter_list, mapping.device_name) == local.filter_contains_value)
+  ]
+}

--- a/ami-block-device-reader/outputs.tf
+++ b/ami-block-device-reader/outputs.tf
@@ -1,0 +1,4 @@
+// Block devices
+output "block_devices" {
+  value = local.block_devices
+}

--- a/ami-block-device-reader/variables.tf
+++ b/ami-block-device-reader/variables.tf
@@ -5,7 +5,7 @@ variable "ami" {
 
 variable "device_filter_type" {
   type        = string
-  description = "How to filter block devices. When `include`, only the devices in `include_device_names` will be returned. When `exclude`, all devices EXCEPT the devices in `exclude_device_names` will be returned."
+  description = "How to filter block devices. When `include`, only the devices in `device_names` will be returned. When `exclude`, all devices EXCEPT the devices in `device_names` (and the root device, if that option is set) will be returned."
 
   validation {
     condition     = var.device_filter_type == "include" || var.device_filter_type == "exclude"
@@ -13,22 +13,16 @@ variable "device_filter_type" {
   }
 }
 
+variable "device_names" {
+  type        = list(string)
+  description = "List of AMI device names to use for filtering. When `device_filter_type` is `exclude`, all devices except those in the list will be included in the output. When `device_filter_type` is `include`, only devices matching the names in the list will be included."
+  default     = []
+}
+
 variable "exclude_root_device" {
   type        = bool
   description = "Whether or not to exclude the root device. This has no effect when device_filter_type is `include`."
   default     = false
-}
-
-variable "exclude_device_names" {
-  type        = list(string)
-  description = "List of AMI devices for which to include in the `block_devices`. When `device_filter_type` is `include`, this has no effect."
-  default     = []
-}
-
-variable "include_device_names" {
-  type        = list(string)
-  description = "List of AMI devices for which to include in the `block_devices`. When `device_filter_type` is `exclude`, this has no effect."
-  default     = []
 }
 
 variable "force_delete_on_termination" {

--- a/ami-block-device-reader/variables.tf
+++ b/ami-block-device-reader/variables.tf
@@ -1,0 +1,38 @@
+variable "ami" {
+  type        = string
+  description = "The AMI to copy devices from."
+}
+
+variable "device_filter_type" {
+  type        = string
+  description = "How to filter block devices. When `include`, only the devices in `include_device_names` will be returned. When `exclude`, all devices EXCEPT the devices in `exclude_device_names` will be returned."
+
+  validation {
+    condition     = var.device_filter_type == "include" || var.device_filter_type == "exclude"
+    error_message = "The device_filter_type variable should be either `include` or `exclude`."
+  }
+}
+
+variable "exclude_root_device" {
+  type        = bool
+  description = "Whether or not to exclude the root device. This has no effect when device_filter_type is `include`."
+  default     = false
+}
+
+variable "exclude_device_names" {
+  type        = list(string)
+  description = "List of AMI devices for which to include in the `block_devices`. When `device_filter_type` is `include`, this has no effect."
+  default     = []
+}
+
+variable "include_device_names" {
+  type        = list(string)
+  description = "List of AMI devices for which to include in the `block_devices`. When `device_filter_type` is `exclude`, this has no effect."
+  default     = []
+}
+
+variable "force_delete_on_termination" {
+  type        = bool
+  description = "Whether to set (to true) the `delete_on_termination` flag for the returned devices."
+  default     = false
+}

--- a/ami-block-device-reader/versions.tf
+++ b/ami-block-device-reader/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      # This may work with earlier versions, however the lowest version
+      # we have currently using it is 2.70.
+      version = ">= 2.70"
+    }
+  }
+}

--- a/ecscluster/main.tf
+++ b/ecscluster/main.tf
@@ -3,29 +3,8 @@ data "aws_ssm_parameter" "golden_ami_latest" {
   name = "/GoldenAMI/Linux/AWS2/latest"
 }
 
-# Look up AMI for `include_ami_device_names`
-data "aws_ami" "default" {
-  filter {
-    name = "image-id"
-    values = [local.ami]
-  }
-}
-
 locals {
   ami = coalesce(var.ami, data.aws_ssm_parameter.golden_ami_latest.value)
-
-  ami_devices = [
-    for mapping in data.aws_ami.default.block_device_mappings :
-      # flatten object so there isn't a nested "ebs" object
-      merge(
-         {device_name = mapping.device_name},
-         mapping.ebs,
-         # overwrite delete_on_termination based on variable
-         var.ami_volumes_delete_on_termination ? { delete_on_termination = true } : {}
-      )
-      # Only include devices specified in `include_ami_device_names`.
-      if contains(var.include_ami_device_names, mapping.device_name)
-  ]
 
   default_devices = [ { device_name = "/dev/xvda",
                         delete_on_termination = true,
@@ -37,6 +16,21 @@ locals {
                         volume_type = null
                       }
                     ]
+}
+
+# TODO: Now that we have this module, I think the `exclude_root_device` option
+# makes more sense than the user providing device names to include. However,
+# we've already deployed the change using the include names to a bunch of
+# repos, so I don't think it makes sense to change this module. If we get a
+# good chance in the future (like if the golden image volume changes from
+# "/dev/sdf", for example), I think we should switch this to just exclude the
+# root volume instead.
+module "ami_devices" {
+  source                      = "../ami-block-device-reader"
+  ami                         = local.ami
+  device_filter_type          = "include"
+  include_device_names        = var.include_ami_device_names
+  force_delete_on_termination = var.ami_volumes_delete_on_termination
 }
 
 module "asg" {
@@ -59,7 +53,7 @@ module "asg" {
   schedule_down        = var.schedule_down
   schedule_up          = var.schedule_up
 
-  block_devices = concat(local.default_devices, local.ami_devices)
+  block_devices = concat(local.default_devices, module.ami_devices.block_devices)
 
   tags = merge(
     var.tags,

--- a/ecscluster/main.tf
+++ b/ecscluster/main.tf
@@ -29,7 +29,7 @@ module "ami_devices" {
   source                      = "../ami-block-device-reader"
   ami                         = local.ami
   device_filter_type          = "include"
-  include_device_names        = var.include_ami_device_names
+  device_names                = var.include_ami_device_names
   force_delete_on_termination = var.ami_volumes_delete_on_termination
 }
 


### PR DESCRIPTION
I need to duplicate this code for DP-28166 (Implement XDR on ephemeral projects), so I decided to split it into its own module rather than copy/paste.

I also updated the `ecscluster` module to use the new module instead of keeping the duplicated code.