### PR TITLE
DP-28166: fix asg module version bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.58] - 2023-07-21
+
+ - [ASG] Fix minimum aws provider version
+
 ## [1.0.57] - 2023-07-17
 
  - [AMI Block Device Reader] Add a module to read and manipulate block devices from an AMI.

--- a/ami-block-device-reader/README.md
+++ b/ami-block-device-reader/README.md
@@ -16,7 +16,7 @@ An example of using this module:
 
 ```terraform
 module "ami_devices" {
-  source                      = "github.com/massgov/mds-terraform-common//aws-block-device-reader?ref=1.0.57"
+  source                      = "github.com/massgov/mds-terraform-common//ami-block-device-reader?ref=1.0.57"
   ami                         = "ami-12345"
 
   # Only include the "/dev/sdf" device

--- a/asg/versions.tf
+++ b/asg/versions.tf
@@ -5,8 +5,8 @@ terraform {
     aws = {
       source = "hashicorp/aws"
       # This may work with earlier versions, however the lowest version
-      # we have currently using it is 2.70.
-      version = ">= 2.70"
+      # we have currently using it is v4.58.0
+      version = ">= 4.58.0"
     }
   }
 }


### PR DESCRIPTION
The `throughput` key in the `ebs_block_volume` block was not allowed in older versions. I am not sure when it was added, so I bumped the minimum version to the lowest version we have currently tested this with.