### PR TITLE
Update AMI ID referenced by ecscluster module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.58] - 2023-08-10
+
+ - [ECS Cluster] Update to use AMI ID parameter maintained by SSR team
+
 ## [1.0.57] - 2023-07-17
 
  - [AMI Block Device Reader] Add a module to read and manipulate block devices from an AMI.

--- a/ecscluster/main.tf
+++ b/ecscluster/main.tf
@@ -1,6 +1,6 @@
 # Default AMI to use when none is specified.
 data "aws_ssm_parameter" "golden_ami_latest" {
-  name = "/GoldenAMI/Linux/AWS2/latest"
+  name = "/infrastructure/amis/golden_aws_linux"
 }
 
 locals {


### PR DESCRIPTION
The `/GoldenAMI/Linux/AWS2/latest` SSM parameter changed unexpectedly this morning to `123456789` because of (probably) a Cloud Team goof-up. This broke builds for all projects that use the `ecscluster` module. In order to ensure this doesn't happen again, we're gonna start using a new parameter that DS SSR maintains.

Successful build using updated module: https://us-east-1.console.aws.amazon.com/codesuite/codebuild/786775234217/projects/HLCEmergencyAssistance-plan/build/HLCEmergencyAssistance-plan%3Ae2c9466c-49ca-4855-b2a6-5d9b2a6f6794?region=us-east-1 