### PR TITLE
DP-29327: Update ecscluster launch template to reconfigure docker root dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.59] - 2023-08-15
+
+ - [ECS Cluster] Update user data to reconfigure docker data dir off of the root EBS volume
+
 ## [1.0.58] - 2023-08-10
 
  - [ECS Cluster] Update to use AMI ID parameter maintained by SSR team

--- a/ecscluster/src/instance_init.yml
+++ b/ecscluster/src/instance_init.yml
@@ -24,8 +24,29 @@ runcmd:
   - "sudo usermod -s /bin/bash ec2-user"
   - "sudo usermod -a -G docker ec2-user"
 
+  # Commands to re-configure the docker data directory
+  - "sudo systemctl stop docker"
+  - |
+    if [ -d /var/lib/docker ]; then
+      sudo mv -f /var/lib/docker /docker
+      sudo ln -s /docker /var/lib/docker
+    fi
+  - |
+    if [ ! -d /docker ]; then
+      sudo mkdir /docker
+    fi
+  # Replicate owner and mode of default directory (/var/lib/docker)
+  - "sudo chown root:root /docker"
+  - "sudo chmod 710 /docker"
+  - "sudo systemctl restart docker"
+
 
 write_files:
+  - content: |
+      {
+        "data-root":"/docker"
+      }
+    path: /etc/docker/daemon.json
   - content: |
       ECS_CLUSTER=${cluster_name}
       ECS_AVAILABLE_LOGGING_DRIVERS=["json-file", "awslogs"]


### PR DESCRIPTION
### Testing
- This version of the launch template is currently in use by the `itd-dv-hlc-airflow` asg: https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#AutoScalingGroupDetails:id=itd-dv-hlc-airflow;view=details
- Verified this morning that the asg spun up an instance and that docker was configured in the expected way:
<img width="618" alt="Screen Shot 2023-08-15 at 9 43 09 AM" src="https://github.com/massgov/mds-terraform-common/assets/12010279/7f5ab7a8-3dcd-4a14-a168-111d76a8ea41">
