### PR TITLE
DP-29327: make docker config process more robust

### DIFF
--- a/ecscluster/src/instance_init.yml
+++ b/ecscluster/src/instance_init.yml
@@ -7,6 +7,20 @@ runcmd:
   - "systemctl enable amazon-ssm-agent"
   - "systemctl start amazon-ssm-agent"
 
+  # Commands to re-configure the docker data directory
+  - |
+    if [ -d /var/lib/docker ]; then
+      sudo mv -f /var/lib/docker /docker
+      sudo ln -s /docker /var/lib/docker
+    fi
+  - |
+    if [ ! -d /docker ]; then
+      sudo mkdir /docker
+    fi
+  # Replicate owner and mode of default directory (/var/lib/docker)
+  - "sudo chown root:root /docker"
+  - "sudo chmod 710 /docker"
+
   # Commands from https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-install.html
   - "sudo amazon-linux-extras disable docker"
   - "sudo amazon-linux-extras install -y ecs"
@@ -23,25 +37,6 @@ runcmd:
   # which also requires the docker group.
   - "sudo usermod -s /bin/bash ec2-user"
   - "sudo usermod -a -G docker ec2-user"
-
-  # Commands to re-configure the docker data directory
-  - "sudo systemctl stop docker"
-  - |
-    if [ -d /var/lib/docker ]; then
-      sudo mv -f /var/lib/docker /docker
-      sudo ln -s /docker /var/lib/docker
-    fi
-  - |
-    if [ ! -d /docker ]; then
-      sudo mkdir /docker
-    fi
-  # Replicate owner and mode of default directory (/var/lib/docker)
-  - "sudo chown root:root /docker"
-  - "sudo chmod 710 /docker"
-  - "sudo systemctl restart docker"
-  # Restarting docker can sometimes take the ecs agent down - make sure it's started
-  - "sudo systemctl start ecs"
-
 
 write_files:
   - content: |

--- a/ecscluster/src/instance_init.yml
+++ b/ecscluster/src/instance_init.yml
@@ -39,12 +39,15 @@ runcmd:
   - "sudo chown root:root /docker"
   - "sudo chmod 710 /docker"
   - "sudo systemctl restart docker"
+  # Restarting docker can sometimes take the ecs agent down - make sure it's started
+  - "sudo systemctl start ecs"
 
 
 write_files:
   - content: |
       {
-        "data-root":"/docker"
+        "data-root":"/docker",
+        "live-restore": true
       }
     path: /etc/docker/daemon.json
   - content: |


### PR DESCRIPTION
Logged onto the dev airflow ec2 instance to find that `ecs-agent` had stopped when the instance was spun down the night before. This is likely because the `user_data` script stops then starts the docker daemon. This adds both `live-reload` to the docker config and explicitly starts the `ecs` service 