### PR TITLE
DP-28939: newrelic metrics stream

### DIFF
--- a/newrelic-metrics/firehose.tf
+++ b/newrelic-metrics/firehose.tf
@@ -55,6 +55,7 @@ resource "aws_kinesis_firehose_delivery_stream" "default" {
 resource "aws_iam_role" "firehose_role" {
   name               = "${var.name_prefix}-newrelic-firehose-role"
   assume_role_policy = data.aws_iam_policy_document.firehose_assume_role.json
+  tags               = var.tags
 }
 
 data "aws_iam_policy_document" "firehose_assume_role" {

--- a/newrelic-metrics/firehose.tf
+++ b/newrelic-metrics/firehose.tf
@@ -31,7 +31,7 @@ resource "aws_kinesis_firehose_delivery_stream" "default" {
     cloudwatch_logging_options {
       enabled         = true
       log_group_name  = aws_cloudwatch_log_group.firehose_logs.name
-      log_stream_name = aws_cloudwatch_log_stream.firehose_logs_http.arn
+      log_stream_name = aws_cloudwatch_log_stream.firehose_logs_http.name
     }
   }
 
@@ -44,7 +44,7 @@ resource "aws_kinesis_firehose_delivery_stream" "default" {
     cloudwatch_logging_options {
       enabled         = true
       log_group_name  = aws_cloudwatch_log_group.firehose_logs.name
-      log_stream_name = aws_cloudwatch_log_stream.firehose_logs_s3.arn
+      log_stream_name = aws_cloudwatch_log_stream.firehose_logs_s3.name
     }
   }
 

--- a/newrelic-metrics/firehose.tf
+++ b/newrelic-metrics/firehose.tf
@@ -1,0 +1,135 @@
+# https://docs.newrelic.com/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup/
+data "aws_caller_identity" "default" {
+}
+
+
+module "firehose_bucket" {
+  source = "../private-bucket"
+  bucket_name = "${var.name_prefix}-newrelic-firehose-data"
+  tags = var.tags
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "default" {
+  name = "${var.name_prefix}-newrelic-firehose-stream"
+  destination = "http_endpoint"
+
+  http_endpoint_configuration {
+    url                = var.newrelic_api_url
+    name               = "New Relic"
+    access_key         = var.newrelic_access_key
+    buffering_size     = var.buffering_size
+    buffering_interval = var.buffering_interval
+    role_arn           = aws_iam_role.firehose_role.arn
+    retry_duration     = var.retry_duration #60
+
+    s3_backup_mode     = "FailedDataOnly"
+
+    request_configuration {
+      content_encoding = "GZIP"
+    }
+
+    cloudwatch_logging_options {
+      enabled         = true
+      log_group_name  = aws_cloudwatch_log_group.firehose_logs.name
+      log_stream_name = aws_cloudwatch_log_stream.firehose_logs_http.arn
+    }
+  }
+
+  # NOTE: When we upgrade the aws terraform provider to >=5, this needs to be
+  # moved inside the http_endpoint_configuration
+  s3_configuration {
+    bucket_arn = module.firehose_bucket.bucket_arn
+    role_arn   = aws_iam_role.firehose_role.arn
+
+    cloudwatch_logging_options {
+      enabled         = true
+      log_group_name  = aws_cloudwatch_log_group.firehose_logs.name
+      log_stream_name = aws_cloudwatch_log_stream.firehose_logs_s3.arn
+    }
+  }
+
+  tags = var.tags
+}
+
+
+resource "aws_iam_role" "firehose_role" {
+  name               = "${var.name_prefix}-newrelic-firehose-role"
+  assume_role_policy = data.aws_iam_policy_document.firehose_assume_role.json
+}
+
+data "aws_iam_policy_document" "firehose_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["firehose.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+
+    # https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#firehose-assume-role
+    condition {
+      test  = "StringEquals"
+      variable = "sts:ExternalId"
+      values = [data.aws_caller_identity.default.account_id]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "firehose_policy" {
+  role = aws_iam_role.firehose_role.id
+  policy = data.aws_iam_policy_document.firehose_policy.json
+}
+
+# https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3
+data "aws_iam_policy_document" "firehose_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:PutObject"
+     ]
+     resources = [
+       module.firehose_bucket.bucket_arn,
+       "${module.firehose_bucket.bucket_arn}/*"
+     ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:PutLogEvents"
+    ]
+    resources = [
+      aws_cloudwatch_log_stream.firehose_logs_http.arn,
+      aws_cloudwatch_log_stream.firehose_logs_s3.arn
+    ]
+  }
+}
+
+resource "aws_cloudwatch_log_group" "firehose_logs" {
+  name              = "/kinesisfirehose/${var.name_prefix}-newrelic-firehose"
+  retention_in_days = 30
+  skip_destroy      = true # We don't have permission to delete these anyways.
+  tags              = merge(
+    var.tags,
+    {
+      "Name" = "${var.name_prefix}-newrelic-firehose"
+    }
+  )
+}
+
+resource "aws_cloudwatch_log_stream" "firehose_logs_http" {
+  name           = "http"
+  log_group_name = aws_cloudwatch_log_group.firehose_logs.name
+}
+
+resource "aws_cloudwatch_log_stream" "firehose_logs_s3" {
+  name           = "s3"
+  log_group_name = aws_cloudwatch_log_group.firehose_logs.name
+}

--- a/newrelic-metrics/main.tf
+++ b/newrelic-metrics/main.tf
@@ -1,0 +1,54 @@
+resource "aws_cloudwatch_metric_stream" "default" {
+  name          = "${var.name_prefix}-newrelic-metric-stream"
+  role_arn      = aws_iam_role.metric_stream_role.arn
+  firehose_arn  = aws_kinesis_firehose_delivery_stream.default.arn
+  output_format = "opentelemetry0.7"
+
+  dynamic "include_filter" {
+    for_each = var.include_filters
+
+    content {
+      namespace    = include_filter.value.namespace
+      metric_names = include_filter.value.metric_names
+    }
+  }
+}
+
+
+// https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-trustpolicy.html
+resource "aws_iam_role" "metric_stream_role" {
+  name               = "${var.name_prefix}-newrelic-metric-stream-role"
+  assume_role_policy = data.aws_iam_policy_document.metric_stream_assume_role.json
+}
+
+data "aws_iam_policy_document" "metric_stream_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["streams.metrics.cloudwatch.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+
+resource "aws_iam_role_policy" "metric_stream_policy" {
+  role = aws_iam_role.metric_stream_role.id
+  policy = data.aws_iam_policy_document.metric_stream_policy.json
+}
+
+data "aws_iam_policy_document" "metric_stream_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "firehose:PutRecord",
+      "firehose:PutRecordBatch",
+     ]
+     resources = [
+       aws_kinesis_firehose_delivery_stream.default.arn
+     ]
+  }
+}

--- a/newrelic-metrics/main.tf
+++ b/newrelic-metrics/main.tf
@@ -3,6 +3,7 @@ resource "aws_cloudwatch_metric_stream" "default" {
   role_arn      = aws_iam_role.metric_stream_role.arn
   firehose_arn  = aws_kinesis_firehose_delivery_stream.default.arn
   output_format = "opentelemetry0.7"
+  tags          = var.tags
 
   dynamic "include_filter" {
     for_each = var.include_filters
@@ -19,6 +20,7 @@ resource "aws_cloudwatch_metric_stream" "default" {
 resource "aws_iam_role" "metric_stream_role" {
   name               = "${var.name_prefix}-newrelic-metric-stream-role"
   assume_role_policy = data.aws_iam_policy_document.metric_stream_assume_role.json
+  tags               = var.tags
 }
 
 data "aws_iam_policy_document" "metric_stream_assume_role" {

--- a/newrelic-metrics/newrelic.tf
+++ b/newrelic-metrics/newrelic.tf
@@ -1,0 +1,56 @@
+resource "newrelic_cloud_aws_link_account" "default" {
+  arn                    = aws_iam_role.newrelic_integration_role.arn
+  metric_collection_mode = "PUSH"
+  name                   = var.newrelic_aws_account_name
+  account_id             = var.newrelic_account_id
+}
+
+resource "aws_iam_role" "newrelic_integration_role" {
+  name               = "${var.name_prefix}-newrelic-integration-role"
+  assume_role_policy = data.aws_iam_policy_document.newrelic_integration_assume_role.json
+}
+
+data "aws_iam_policy_document" "newrelic_integration_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      # New Relic's AWS account id - from https://docs.newrelic.com/docs/infrastructure/amazon-integrations/connect/connect-aws-new-relic-infrastructure-monitoring/#connect
+      identifiers = [754728514883]
+    }
+
+    # Make sure the "ExternalId" matches the New Relic account id.
+    condition {
+      test     = "StringEquals"
+      values   = [var.newrelic_account_id]
+      variable = "sts:ExternalId"
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role_policy" "newrelic_integration_policy" {
+  role = aws_iam_role.newrelic_integration_role.id
+  policy = data.aws_iam_policy_document.newrelic_integration_policy.json
+}
+
+data "aws_iam_policy_document" "newrelic_integration_policy" {
+  statement {
+    effect = "Allow"
+    # Required permissions from https://docs.newrelic.com/docs/infrastructure/amazon-integrations/get-started/integrations-managed-policies/#list-permissions
+    actions = [
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:ListMetrics",
+      "cloudwatch:GetMetricData",
+      # I thought I saw somewhere that the config: roles weren't actually required,
+      # but now I can't find it. We could try removing them once we have this working?
+      "config:BatchGetResourceConfig",
+      "config:ListDiscoveredResources",
+      "tag:GetResources"
+     ]
+
+     resources = ["*"]
+  }
+}

--- a/newrelic-metrics/newrelic.tf
+++ b/newrelic-metrics/newrelic.tf
@@ -8,6 +8,7 @@ resource "newrelic_cloud_aws_link_account" "default" {
 resource "aws_iam_role" "newrelic_integration_role" {
   name               = "${var.name_prefix}-newrelic-integration-role"
   assume_role_policy = data.aws_iam_policy_document.newrelic_integration_assume_role.json
+  tags               = var.tags
 }
 
 data "aws_iam_policy_document" "newrelic_integration_assume_role" {

--- a/newrelic-metrics/variables.tf
+++ b/newrelic-metrics/variables.tf
@@ -1,0 +1,60 @@
+variable "name_prefix" {
+  type        = string
+  description = "A name prefix to use for created resources."
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-]*[a-zA-Z0-9]+$", var.name_prefix))
+    error_message = "Prefix should only contain alphanumeric characters and (optionally) dashes. It must not end in a dash."
+  }
+}
+
+variable "newrelic_api_url" {
+  type        = string
+  description = "The New Relic api url. The default is the US url."
+  default     = "https://aws-api.newrelic.com/cloudwatch-metrics/v1"
+}
+
+variable "newrelic_access_key" {
+  type        = string
+  description = "The new relic access key."
+}
+
+variable "newrelic_aws_account_name" {
+  type        = string
+  description = "Nickname for AWS account in New Relic."
+}
+
+variable "newrelic_account_id" {
+  type        = string
+  description = "The account number for the New Relic account."
+}
+
+variable "buffering_size" {
+  type        = number
+  description = "Buffer size for http configuration. See kinesis_firehose_delivery_stream.http_endpoint_configuration.buffering_size."
+  default     = 1 # Default recommended by New Relic
+}
+
+variable "buffering_interval" {
+  type        = number
+  description = "Buffer interval for http configuration. See kinesis_firehose_delivery_stream.http_endpoint_configuration.buffering_interval."
+  default     = 60 # Default recommended by New Relic
+}
+
+variable "retry_duration" {
+  type        = number
+  description = "Retry duration for http configuration. See kinesis_firehose_delivery_stream.http_endpoint_configuration.retry_duration."
+  default     = 60 # Default recommended by New Relic
+}
+
+variable "include_filters" {
+  type        = list(object({
+                  namespace = string,
+                  metric_names = list(string)
+                }))
+  description = "List of metrics to include. See aws_cloudwatch_metric_stream.include_filter. Note - empty metric_names list will include all metrics."
+}
+
+variable "tags" {
+  type = map(string)
+  default = {}
+}

--- a/newrelic-metrics/versions.tf
+++ b/newrelic-metrics/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      # 4.67 is the first version that allows `metric_names` for
+      # the include_filters
+      version = ">= 4.67"
+    }
+
+    newrelic = {
+      source  = "newrelic/newrelic"
+      version = ">= 2.44"
+    }
+  }
+}

--- a/private-bucket/main.tf
+++ b/private-bucket/main.tf
@@ -11,9 +11,19 @@ resource "aws_s3_bucket" "default" {
   )
 }
 
+resource "aws_s3_bucket_ownership_controls" "default" {
+  bucket = aws_s3_bucket.default.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "default" {
   bucket = aws_s3_bucket.default.id
   acl = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.default]
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "default" {


### PR DESCRIPTION
This PR adds a module that creates a CloudWatch metric stream that sends the data through a Kinesis Firehose into New Relic. It also adds the configuration that is needed on the New Relic side.

See https://docs.newrelic.com/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup/#manual-setup

Other relevant links have been included as comments in the code