### PR TITLE
DP-29791: set min/max ttl defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.0.63] - 2023-09-13
+## [1.0.63] - 2023-09-21
 
  - [Static Site] Expose CloudFront min/max TTL variables
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.63] - 2023-09-13
+
+ - [Static Site] Expose CloudFront min/max TTL variables
+
 ## [1.0.62] - 2023-09-13
 
  - [New Relic] Add New Relic integration.

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -176,7 +176,9 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
     allowed_methods        = var.allowed_methods
     cached_methods         = var.cached_methods
     target_origin_id       = "default"
-    default_ttl = var.default_ttl
+    min_ttl                = var.min_ttl
+    default_ttl            = var.default_ttl
+    max_ttl                = var.min_ttl
 
     // There is no backend processing in this case, so we can skip forwarding
     // things like query string and cookies. CORS headers are forwarded, if

--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -178,7 +178,7 @@ resource "aws_cloudfront_distribution" "domain_distribution" {
     target_origin_id       = "default"
     min_ttl                = var.min_ttl
     default_ttl            = var.default_ttl
-    max_ttl                = var.min_ttl
+    max_ttl                = var.max_ttl
 
     // There is no backend processing in this case, so we can skip forwarding
     // things like query string and cookies. CORS headers are forwarded, if

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -51,10 +51,22 @@ variable "cached_methods" {
   default = ["GET", "HEAD", "OPTIONS"]
 }
 
+variable "min_ttl" {
+  type = number
+  description = "The minimum amount of time, in seconds, that objects stay in the CloudFront's cache."
+  default = 0
+}
+
 variable "default_ttl" {
-  type = string
+  type = number
   description = "The cache TTL that will be used if no Cache-Control headers are present."
   default = 3600
+}
+
+variable "max_ttl" {
+  type = number
+  description = "The maximum amount of time, in seconds, that objects stay in CloudFront's cache."
+  default = 31536000 # one year
 }
 
 variable "enable_cors" {

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -61,12 +61,20 @@ variable "default_ttl" {
   type = number
   description = "The cache TTL that will be used if no Cache-Control headers are present."
   default = 3600
+  validation {
+    condition     = var.default_ttl >= var.min_ttl
+    error_message = "Default TTL value must be greater than or equal to minimum TTL value"
+  }
 }
 
 variable "max_ttl" {
   type = number
   description = "The maximum amount of time, in seconds, that objects stay in CloudFront's cache."
   default = 31536000 # one year
+  validation {
+    condition     = var.max_ttl >= var.default_ttl
+    error_message = "Max TTL value must be greater than or equal to default TTL value"
+  }
 }
 
 variable "enable_cors" {

--- a/static-site/variables.tf
+++ b/static-site/variables.tf
@@ -61,20 +61,12 @@ variable "default_ttl" {
   type = number
   description = "The cache TTL that will be used if no Cache-Control headers are present."
   default = 3600
-  validation {
-    condition     = var.default_ttl >= var.min_ttl
-    error_message = "Default TTL value must be greater than or equal to minimum TTL value"
-  }
 }
 
 variable "max_ttl" {
   type = number
   description = "The maximum amount of time, in seconds, that objects stay in CloudFront's cache."
   default = 31536000 # one year
-  validation {
-    condition     = var.max_ttl >= var.default_ttl
-    error_message = "Max TTL value must be greater than or equal to default TTL value"
-  }
 }
 
 variable "enable_cors" {


### PR DESCRIPTION
We're currently running into issues deploying a new static site consistent with this known `aws` provider bug: https://github.com/hashicorp/terraform-provider-aws/issues/17878. This PR updates the `static-site` module to expose `min_ttl` and `max_ttl` variables, and uses them to explicitly set the corresponding variables on `aws_cloudfront_distribution.domain_distribution.default_cache_behavior` so that we don't run into incompatible TTL values in the future