### PR TITLE
DP-28939: Separete loss of signal from cpu alert

### DIFF
--- a/newrelic/alert-conditions-ec2/variables.tf
+++ b/newrelic/alert-conditions-ec2/variables.tf
@@ -49,8 +49,8 @@ variable "critical_threshold_duration" {
   default     = 300
 }
 
-variable "open_violation_on_expiration" {
+variable "alert_loss_of_signal" {
   type        = bool
-  description = "See newrelic_nrql_alert_condition.open_violation_on_expiration."
+  description = "Create an alert when metrics from an instance name stop."
   default     = false
 }


### PR DESCRIPTION
Having signal expiration tied to instance id is a bad idea, because every time we do an instance refresh we will get alerts that hang out for 3 days if they're not closed. This PR makes a separate "fake" alert condition on CPU, but facets by name, and uses that to monitor the signal expiration. That way, if `itd-pr-etl` goes down, we don't care as long as another `itd-pr-etl` comes back up soon after.