### PR TITLE
DP-29923: add alert conditions for lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.80] - 2023-11-21
+
+ - [New Relic] Add Lambda alerts
+
 ## [1.0.79] - 2023-11-17
 
  - [Static Site] Use domain-certificate module (DRY)

--- a/newrelic/alert-conditions-lambda/main.tf
+++ b/newrelic/alert-conditions-lambda/main.tf
@@ -81,7 +81,7 @@ resource "newrelic_nrql_alert_condition" "duration" {
   violation_time_limit_seconds = 259200
 
   nrql {
-    query = "SELECT sum(`aws.lambda.Duration.byFunction`) FROM Metric ${local.filter_subquery} FACET `aws.lambda.FunctionName`"
+    query = "SELECT average(`aws.lambda.Duration.byFunction`) FROM Metric ${local.filter_subquery} FACET `aws.lambda.FunctionName`"
   }
 
   critical {

--- a/newrelic/alert-conditions-lambda/main.tf
+++ b/newrelic/alert-conditions-lambda/main.tf
@@ -86,7 +86,7 @@ resource "newrelic_nrql_alert_condition" "duration" {
 
   critical {
     operator = "above"
-    threshold = var.events_dropped_threshold
+    threshold = var.duration_threshold
     threshold_duration = var.critical_threshold_duration
     threshold_occurrences = "all"
   }

--- a/newrelic/alert-conditions-lambda/main.tf
+++ b/newrelic/alert-conditions-lambda/main.tf
@@ -5,7 +5,10 @@ locals {
   function_names_quoted = join(", ", formatlist("'%s'", var.filter_function_names))
   function_names_subquery = length(var.filter_function_names) == 0 ? "" : "`aws.lambda.FunctionName` IN (${local.function_names_quoted})"
 
-  filter_subqueries_and = join(" AND ", compact([local.aws_accounts_subquery, local.function_names_subquery]))
+  function_names_exclude_quoted = join(", ", formatlist("'%s'", var.exclude_function_names))
+  function_names_exclude_subquery = length(var.exclude_function_names) == 0 ? "" : "`aws.lambda.FunctionName` NOT IN (${local.function_names_exclude_quoted})"
+
+  filter_subqueries_and = join(" AND ", compact([local.aws_accounts_subquery, local.function_names_subquery, local.function_names_exclude_subquery]))
 
   filter_subquery = length(local.filter_subqueries_and) == 0 ? "" : "WHERE (${local.filter_subqueries_and})"
 }

--- a/newrelic/alert-conditions-lambda/main.tf
+++ b/newrelic/alert-conditions-lambda/main.tf
@@ -1,0 +1,101 @@
+locals {
+  aws_accounts_quoted = join(", ", formatlist("'%s'", var.filter_aws_accounts))
+  aws_accounts_subquery = length(var.filter_aws_accounts) == 0 ? "" : "aws.accountId IN (${local.aws_accounts_quoted})"
+
+  function_names_quoted = join(", ", formatlist("'%s'", var.filter_function_names))
+  function_names_subquery = length(var.filter_function_names) == 0 ? "" : "`aws.lambda.FunctionName` IN (${local.function_names_quoted})"
+
+  filter_subqueries_and = join(" AND ", compact([local.aws_accounts_subquery, local.function_names_subquery]))
+
+  filter_subquery = length(local.filter_subqueries_and) == 0 ? "" : "WHERE (${local.filter_subqueries_and})"
+}
+
+resource "newrelic_nrql_alert_condition" "error_percent" {
+  count = (var.error_percent_threshold == null ? 0 : 1)
+
+  account_id = var.account_id
+  policy_id = var.alert_policy_id
+  type = "static"
+  name = "${var.name_prefix} - Error Percent"
+  enabled = true
+  violation_time_limit_seconds = 259200
+
+  nrql {
+    query = "SELECT average(`aws.lambda.Errors.byFunction`) * 100 FROM Metric ${local.filter_subquery} FACET `aws.lambda.FunctionName`"
+  }
+
+  critical {
+    operator = "above"
+    threshold = var.error_percent_threshold
+    threshold_duration = var.critical_threshold_duration
+    threshold_occurrences = "all"
+  }
+
+  fill_option = "last_value"
+  aggregation_window = var.aggregation_window
+  aggregation_method = "event_timer"
+  aggregation_timer = 60
+
+  open_violation_on_expiration = false
+  close_violations_on_expiration = false
+}
+
+resource "newrelic_nrql_alert_condition" "events_dropped" {
+  count = (var.events_dropped_threshold == null ? 0 : 1)
+
+  account_id = var.account_id
+  policy_id = var.alert_policy_id
+  type = "static"
+  name = "${var.name_prefix} - Events Dropped"
+  enabled = true
+  violation_time_limit_seconds = 259200
+
+  nrql {
+    query = "SELECT sum(`aws.lambda.AsyncEventsDropped`) FROM Metric ${local.filter_subquery} FACET `aws.lambda.FunctionName`"
+  }
+
+  critical {
+    operator = "above"
+    threshold = var.events_dropped_threshold
+    threshold_duration = var.critical_threshold_duration
+    threshold_occurrences = "all"
+  }
+
+  fill_option = "none"
+  aggregation_window = var.aggregation_window
+  aggregation_method = "event_timer"
+  aggregation_timer = 60
+
+  open_violation_on_expiration = false
+  close_violations_on_expiration = false
+}
+
+resource "newrelic_nrql_alert_condition" "duration" {
+  count = (var.duration_threshold == null ? 0 : 1)
+
+  account_id = var.account_id
+  policy_id = var.alert_policy_id
+  type = "static"
+  name = "${var.name_prefix} - Duration"
+  enabled = true
+  violation_time_limit_seconds = 259200
+
+  nrql {
+    query = "SELECT sum(`aws.lambda.Duration.byFunction`) FROM Metric ${local.filter_subquery} FACET `aws.lambda.FunctionName`"
+  }
+
+  critical {
+    operator = "above"
+    threshold = var.events_dropped_threshold
+    threshold_duration = var.critical_threshold_duration
+    threshold_occurrences = "all"
+  }
+
+  fill_option = "none"
+  aggregation_window = var.aggregation_window
+  aggregation_method = "event_timer"
+  aggregation_timer = 60
+
+  open_violation_on_expiration = false
+  close_violations_on_expiration = false
+}

--- a/newrelic/alert-conditions-lambda/variables.tf
+++ b/newrelic/alert-conditions-lambda/variables.tf
@@ -1,0 +1,75 @@
+variable "name_prefix" {
+  type        = string
+  description = "Name prefix for the alert condition"
+}
+
+variable "account_id" {
+  type        = string
+  description = "The account number for the New Relic account."
+}
+
+variable "alert_policy_id" {
+  type        = string
+  description = "The id of the New Relic alert policy."
+}
+
+variable "filter_aws_accounts" {
+  type        = list(string)
+  description = "List of AWS account ids to monitor."
+  default     = []
+}
+
+variable "filter_function_names" {
+  type        = list(string)
+  description = "List of Lambda Function names to monitor."
+  default     = []
+}
+
+variable "aggregation_window" {
+  type        = number
+  description = "See newrelic_nrql_alert_condition.aggregation_window."
+  default     = 3600
+}
+
+# This should be, at minimum, the frequency at which the lambda runs. If this
+# only runs once per hour, then it should be at least 3600.
+variable "critical_threshold_duration" {
+  type        = number
+  description = "See newrelic_nrql_alert_condition.critical.threshold_duration."
+  default     = 3600
+}
+
+variable "error_percent_threshold" {
+  description = "Maximum Error percentage (0 - 100%) allowed before triggering alert."
+  default     = 5
+
+  validation {
+    condition     = tonumber(var.error_percent_threshold) == var.error_percent_threshold || var.error_percent_threshold == null
+    error_message = "The error_percent_threshold value should either be a number or null (which would disable the error_percent alert)."
+  }
+
+  validation {
+    condition     = var.error_percent_threshold == null || (var.error_percent_threshold >= 0 && var.error_percent_threshold <= 100)
+    error_message = "The error_percent_threshold value should be between 0 and 100 (or null)."
+  }
+}
+
+variable "events_dropped_threshold" {
+  description = "Maximum number of dropped events allowed before triggering alert."
+  default     = 1
+
+  validation {
+    condition     = tonumber(var.events_dropped_threshold) == var.events_dropped_threshold || var.events_dropped_threshold == null
+    error_message = "The events_dropped_threshold value should either be a number or null (which would disable the events_dropped alert)."
+  }
+}
+
+variable "duration_threshold" {
+  description = "Duration (in milliseconds) allowed before triggering alert."
+  default     = 300000
+
+  validation {
+    condition     = tonumber(var.duration_threshold) == var.duration_threshold || var.duration_threshold == null
+    error_message = "The duration_threshold value should either be a number or null (which would disable the duration alert)."
+  }
+}

--- a/newrelic/alert-conditions-lambda/variables.tf
+++ b/newrelic/alert-conditions-lambda/variables.tf
@@ -25,6 +25,12 @@ variable "filter_function_names" {
   default     = []
 }
 
+variable "exclude_function_names" {
+  type        = list(string)
+  description = "List of Lambda Function names to NOT monitor (all others will be monitored)."
+  default     = []
+}
+
 variable "aggregation_window" {
   type        = number
   description = "See newrelic_nrql_alert_condition.aggregation_window."

--- a/newrelic/alert-conditions-lambda/versions.tf
+++ b/newrelic/alert-conditions-lambda/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    newrelic = {
+      source  = "newrelic/newrelic"
+      version = ">= 2.44"
+    }
+  }
+}


### PR DESCRIPTION
I did something slightly different for these alerts and I want another opinion on it.

In the other modules, for the most part, they create whatever alerts and you don't have any control over it. One exception is https://github.com/massgov/mds-terraform-common/blob/1.x/newrelic/alert-conditions-ec2/variables.tf#L52 , where you can configure the loss of signal alert with an extra variable.

For this one, I made all the threshold values nullable so you can enable/disable exactly which alerts you want. Originally they were all null by default, which makes sense to me, because when you update a module it seems like it would be a pain to have to go in and disable any new alerts that have been added that might not be appropriate. Then I went to test it, and I was _baffled_ as to why it wasn't creating any new alerts. So I switched them to all be enabled by default, with the reasoning that unwanted alerts will at least make themselves known, but alerts you intended to create but didn't might go unnoticed until there is a real problem with the site.

Does this seem reasonable? The whole reason this is necessary is because the `error_rate` and `duration` alerts are kind of finicky on lambdas that run less often than every 2 hours.