### PR TITLE
DP-30774: allow consumers to turn off cleanup lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.78] - 2023-11-13
+
+ - [RDS] Allow consumers to turn off cleanup lambda
+
 ## [1.0.77] - 2023-11-08
 
  - [VPC Read] Upgrade to latest syntax for subnet ID lists

--- a/rdsinstance/main.tf
+++ b/rdsinstance/main.tf
@@ -171,6 +171,7 @@ module "backup_lambda" {
 }
 
 module "cleanup_lambda" {
+  count   = var.enable_manual_snapshots ? 1 : 0
   source  = "github.com/massgov/mds-terraform-common//lambda?ref=1.0.47"
   name    = "${aws_db_instance.default.id}-cleanup-lambda"
   package = "${path.module}/dist/cleanup_lambda.zip"


### PR DESCRIPTION
Now that we've set up RDS backups in SSM, the maintenance calendar tasks now conflict with backup/cleanup lambdas. This PR enables us to turn off completely that functionality.