### PR TITLE
DP-30926: nonsensitive geo restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.82] - 2023-12-01
+
+ - [CloudFront Geo Restriction] Mark country codes as nonsensitive in terraform.
+
 ## [1.0.81] - 2023-11-29
 
  - [Golden AMI Backup] Adds a reusable Lambda function for making automated copies of Golden AMIs

--- a/cloudfront_geo_restriction/main.tf
+++ b/cloudfront_geo_restriction/main.tf
@@ -3,5 +3,5 @@ data "aws_ssm_parameter" "country_codes" {
 }
 
 locals {
-  locations = data.aws_ssm_parameter.country_codes.value == "" ? [] : split(",", data.aws_ssm_parameter.country_codes.value)
+  locations = data.aws_ssm_parameter.country_codes.value == "" ? [] : split(",", nonsensitive(data.aws_ssm_parameter.country_codes.value))
 }

--- a/cloudfront_geo_restriction/versions.tf
+++ b/cloudfront_geo_restriction/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.15"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/cloudfront_geo_restriction_v2/main.tf
+++ b/cloudfront_geo_restriction_v2/main.tf
@@ -1,5 +1,5 @@
 module "cf_geo_restriction" {
-  source  = "github.com/massgov/mds-terraform-common//cloudfront_geo_restriction?ref=1.0.51"
+  source  = "../cloudfront_geo_restriction"
   enabled = true
 }
 

--- a/cloudfront_geo_restriction_v2/versions.tf
+++ b/cloudfront_geo_restriction_v2/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.15"
   required_providers {
     aws = {
       source = "hashicorp/aws"


### PR DESCRIPTION
In later versions of terraform, `aws_ssm_parameter` values are always marked sensitive. This prevents the values (and any values derived from them) from being used in for_each loops, which cloudfront_geo_restriction_v2 requires.