### PR TITLE
updated S3 scanner to use region in Cf Origin Point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ override.tf.json
 # Include override files you do wish to add to version control using negated pattern
 #
 # !example_override.tf
+.idea/

--- a/entrypoint-monitoring/lambda/src/lib/scanner/S3Scanner.ts
+++ b/entrypoint-monitoring/lambda/src/lib/scanner/S3Scanner.ts
@@ -44,7 +44,7 @@ export default class S3Scanner extends BaseScanner implements Scanner {
       this.logger.debug(`- ${bucketName} bucket.`)
 
       // CloudFront links to an S3 bucket the following way.
-      const cfOriginPoint = `${bucketName}.s3.amazonaws.com`
+      const cfOriginPoint = `${bucketName}.s3.${region}.amazonaws.com`;
       interconnections.addPointToServiceLink(
         cfOriginPoint,
         this.serviceType,


### PR DESCRIPTION
With ticket   [DP-32223](https://massgov.atlassian.net/browse/DP-32223) was determine that the scanner logic should be updated to use region in s3 origin domain. This is now best practice as S3 buckets standards have been moved away from using global S3 bucket endpoints. 

[DP-32223]: https://massgov.atlassian.net/browse/DP-32223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ