### PR TITLE
DP-31742: prevent reserved tags from being applied to image builder resources

### DIFF
--- a/golden-ami-builder/main.tf
+++ b/golden-ami-builder/main.tf
@@ -167,7 +167,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "golden_ami" {
   resource_tags = {
     # 'CreatedBy' and 'Ec2ImageBuilderArn' are reserved tags for instances created by
     # Image Builder. Trying to provide either will kill deployments
-    for k, v in var.tags : k => v if !contains(["createdby", "ec2imagebuilderarn"], k)
+    for k, v in var.tags : k => v if !contains(["createdby", "ec2imagebuilderarn"], lower(k))
   }
   tags = var.tags
 }

--- a/golden-ami-builder/main.tf
+++ b/golden-ami-builder/main.tf
@@ -165,11 +165,11 @@ resource "aws_imagebuilder_infrastructure_configuration" "golden_ami" {
   }
 
   resource_tags = {
-    # 'createdby' is a reserved tag for instances created by Image Builder.
-    # Trying to set it here will kill deployments
-    for k,v in var.tags: k => v if lower(k) != "createdby"
+    # 'CreatedBy' and 'Ec2ImageBuilderArn' are reserved tags for instances created by
+    # Image Builder. Trying to provide either will kill deployments
+    for k, v in var.tags : k => v if !contains(["createdby", "ec2imagebuilderarn"], k)
   }
-  tags          = var.tags
+  tags = var.tags
 }
 
 resource "aws_imagebuilder_component" "download_and_install_cortex_xdr" {

--- a/golden-ami-builder/main.tf
+++ b/golden-ami-builder/main.tf
@@ -165,7 +165,8 @@ resource "aws_imagebuilder_infrastructure_configuration" "golden_ami" {
   }
 
   resource_tags = {
-    # 'createdby' is a reserved tag for instances created by Image Builder
+    # 'createdby' is a reserved tag for instances created by Image Builder.
+    # Trying to set it here will kill deployments
     for k,v in var.tags: k => v if lower(k) != "createdby"
   }
   tags          = var.tags

--- a/golden-ami-builder/main.tf
+++ b/golden-ami-builder/main.tf
@@ -164,7 +164,10 @@ resource "aws_imagebuilder_infrastructure_configuration" "golden_ami" {
     }
   }
 
-  resource_tags = var.tags
+  resource_tags = {
+    # 'createdby' is a reserved tag for instances created by Image Builder
+    for k,v in var.tags: k => v if lower(k) != "createdby"
+  }
   tags          = var.tags
 }
 


### PR DESCRIPTION
This is a fast follow to unbreak the DH and Core deployments