### PR TITLE
DP-33136: Add variable for RDS autoscaling with max_allocatable_storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.92] - 2024-05-13
+
+- [RDS] Add option for RDS auto scaling with max_allocatable_storage
+
 ## [1.0.91] - 2024-04-25
 
 - [Golden AMI Lookup] Update regex to look up SSR Image Builder AMI instead

--- a/rdsinstance/main.tf
+++ b/rdsinstance/main.tf
@@ -11,6 +11,7 @@ resource "aws_db_subnet_group" "default" {
 resource "aws_db_instance" "default" {
   identifier                            = var.name
   allocated_storage                     = var.allocated_storage
+  max_allocated_storage                 = var.max_allocated_storage
   storage_type                          = "gp2"
   engine                                = var.engine
   engine_version                        = var.engine_version

--- a/rdsinstance/variables.tf
+++ b/rdsinstance/variables.tf
@@ -63,6 +63,12 @@ variable "allocated_storage" {
   default     = 10
 }
 
+variable "max_allocated_storage" {
+  type        = string
+  description = "If defined, will enable Storage Autoscaling. Must be higher than allocated_storage."
+  default     = null
+}
+
 variable "storage_encrypted" {
   type        = string
   description = "Boolean indicating whether to encrypt the disk or not"


### PR DESCRIPTION
This configuration variable will allow an RDS instance to utilize autoscaling to avoid having to know resource size ahead of time.