### PR TITLE
DP-33139: Add ca_cert_identifier variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.94] - 2024-05-21
+
+- [RDS] Add `ca_cert_identifier` variable.
+
 ## [1.0.93] - 2024-05-13
 
 - [Github to Teams] Upgrade lambda runtime to node20

--- a/rdsinstance/main.tf
+++ b/rdsinstance/main.tf
@@ -32,6 +32,8 @@ resource "aws_db_instance" "default" {
   allow_major_version_upgrade           = var.allow_major_version_upgrade
   apply_immediately                     = var.apply_immediately
   iam_database_authentication_enabled   = var.iam_database_authentication_enabled
+  ca_cert_identifier                    = var.ca_cert_identifier
+
   vpc_security_group_ids = flatten([
     var.security_groups,
     aws_security_group.db.id,

--- a/rdsinstance/variables.tf
+++ b/rdsinstance/variables.tf
@@ -185,3 +185,9 @@ variable "backup_error_topics" {
   description = "An array of SNS topics to publish notifications to when backups error out"
   default     = []
 }
+
+variable "ca_cert_identifier" {
+  type        = string
+  description = "The identifier of the CA certificate for the DB instance."
+  default     = null
+}


### PR DESCRIPTION
By default, if a value isn't supplied, AWS will use the account-level default certificate, which seems like good behavior to keep. For that reason, the default value for the variable is `null`.