### PR TITLE
DP-33139: Changes for aws provider v5 compatability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.98] - 2024-07-22
+
+- [ASG] Add optional `AmazonECSManaged` tag to autoscaling group to be compatible with aws provider v5.
+- [ECS] Add variable to disable `AmazonECSManaged` tag in autoscaling group.
+- [RDS] Add `rds_instance_identifier` output for aws provider v5.
+- [RDS] Switch `aws_db_instance.id` to `aws_db_instance.identifier` to be compatible with aws provider v5.
+
 ## [1.0.97] - 2024-07-17
 
 - [RDS] Add `ca_cert_identifier` variable.

--- a/asg/main.tf
+++ b/asg/main.tf
@@ -87,6 +87,16 @@ resource "aws_autoscaling_group" "default" {
     propagate_at_launch = false
     value               = var.name
   }
+
+  dynamic "tag" {
+    for_each = var.amazon_ecs_managed_tag ? [1] : []
+
+    content {
+      key                 = "AmazonECSManaged"
+      propagate_at_launch = true
+      value               = "true"
+    }
+  }
 }
 
 resource "aws_autoscaling_schedule" "schedule_down" {

--- a/asg/variables.tf
+++ b/asg/variables.tf
@@ -130,3 +130,9 @@ variable "block_devices" {
     }
   ]
 }
+
+variable "amazon_ecs_managed_tag" {
+  type        = bool
+  description = "Whether or not to include the AmazonECSManaged tag."
+  default     = true
+}

--- a/ecscluster/main.tf
+++ b/ecscluster/main.tf
@@ -78,6 +78,8 @@ module "asg" {
 
   block_devices = concat(local.default_devices, module.ami_devices.block_devices)
 
+  amazon_ecs_managed_tag  = var.amazon_ecs_managed_tag
+
   tags = merge(
     var.tags,
     {

--- a/ecscluster/variables.tf
+++ b/ecscluster/variables.tf
@@ -115,3 +115,9 @@ variable "additional_cloudinit_configs" {
   DESC
   default = []
 }
+
+variable "amazon_ecs_managed_tag" {
+  type        = bool
+  description = "Whether or not to include the AmazonECSManaged tag to the autoscaling group."
+  default     = true
+}

--- a/rdsinstance/outputs.tf
+++ b/rdsinstance/outputs.tf
@@ -20,6 +20,8 @@ output "port" {
 
 // RDS Instance ID.
 output "rds_instance_id" {
+  # NOTE: You probably want `rds_instance_identifier` instead, as this changed
+  # in version 5 of the aws provider.
   value = aws_db_instance.default.id
 }
 
@@ -36,4 +38,8 @@ output "rds_resource_id" {
 // Security group that is allowed to access the database.
 output "accessor_security_group" {
   value = aws_security_group.db_accessor.id
+}
+
+output "rds_instance_identifier" {
+  value = aws_db_instance.default.identifier
 }


### PR DESCRIPTION
ASG:
  - Added the `AmazonECSManaged` tag to the autoscaling group. This is set on all of our ASGs, but as of aws provider version 5, terraform wants to remove it since it is not defined in the code anywhere.
  - Added a `amazon_ecs_managed_tag` variable so the above tag can be disabled if necessary.

ECS:
  - Added a `amazon_ecs_managed_tag` variable so the `AmazonECSManaged` tag can be disabled in the auto scaling group.

RDS:
  - `rds_snapshot_delete` policy was being defined even when it wasn't used. This made the plan somewhat confusing when I was dealing with other upgrade issues. I've fixed it so that it only defines the policy when it will be used.
  - `aws_db_instance.id` changes im aws provider v5. It no longer references the `identifier` attribute. I changed all uses of the `id` attribute within the module to use `identifier` instead.
  - Added `rds_instance_identifier` output, which refers to the `identifier` attribute. I did not change the `rds_instance_id` output.
      - **NOTE:** Curious if anyone has any opinions on this. To me it felt like `rds_instance_id` should be equal to whatever `aws_rds_instance.id` is, since that is what the name suggests. However, I am pretty sure everywhere we use this output, what we actually want is `identifier`. For the repos I am aware of, we only use it in one or two places (and I will be updating them immediately as part of this ticket), so it should be easy enough to fix. That feels better to me than switching the other output, which could be used somewhere I don't know about, and could potentially break if the `rds_instance_id` was changed. One other option I considered was deleting the `rds_instance_id` output, so that it is clear to anyone updating to this module that something has changed.