### PR TITLE
DP-33359: Update entrypoint monitor to use regional bucket endpoints (again) (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.100] - 2024-08-05
+
+- [Entrypoint Monitor] Update permissions so Lambda can read bucket location
+
 ## [1.0.99] - 2024-07-24
 
 - [Static Site] Replace deprecated `website` block with `aws_s3_bucket_website_configuration`.

--- a/entrypoint-monitoring/main.tf
+++ b/entrypoint-monitoring/main.tf
@@ -31,6 +31,7 @@ data "aws_iam_policy_document" "monitor_inline_policy" {
       "route53:ListResourceRecordSets",
       "s3:ListAllMyBuckets",
       "s3:GetBucketWebsite",
+      "s3:GetBucketLocation"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
Karen asked why we were still seeing entrypoint monitor alerts after I allegedly fixed the tool. I looked at the logs and saw
```
2024-08-04T04:30:30.570Z	bcdb6c3f-db4a-4e7c-8f74-41b1189e91da	INFO	==== Scanning S3 Buckets... ====
2024-08-04T04:30:30.570Z	bcdb6c3f-db4a-4e7c-8f74-41b1189e91da	ERROR	Insufficient permissions to get abcs.digital.mass.gov bucket location
2024-08-04T04:30:30.570Z	bcdb6c3f-db4a-4e7c-8f74-41b1189e91da	ERROR	Insufficient permissions to get acquia-files-backup.digital.mass.gov bucket location
2024-08-04T04:30:30.570Z	bcdb6c3f-db4a-4e7c-8f74-41b1189e91da	ERROR	Insufficient permissions to get anf-budget-dev.digital.mass.gov bucket location
2024-08-04T04:30:30.648Z	bcdb6c3f-db4a-4e7c-8f74-41b1189e91da	ERROR	Insufficient permissions to get api-data.mass.gov bucket location
2024-08-04T04:30:30.648Z	bcdb6c3f-db4a-4e7c-8f74-41b1189e91da	ERROR	Insufficient permissions to get api-elasticsearch.digital.mass.gov bucket location
2024-08-04T04:30:30.648Z	bcdb6c3f-db4a-4e7c-8f74-41b1189e91da	ERROR	Insufficient permissions to get api-muni.digital.mass.gov bucket location
2024-08-04T04:30:30.648Z	bcdb6c3f-db4a-4e7c-8f74-41b1189e91da	ERROR	Insufficient permissions to get api-upload.digital.mass.gov bucket location
```
so I've added `s3:GetBucketLocation` to the lambda role.