### PR TITLE
DP-34372: Pull the New Relic bits out of newrelic/metrics-stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - [RDS] Update module to enable AWS-managed master passwords
 - [Teams alert] Update module to support reading Teams webhook URL from Parameter Store
 
+### Breaking
+
+- [New Relic] Remove New Relic-AWS link from `metrics-stream` submodule
+
 ## [1.0.101] - 2024-08-31
 
 - [Role Escalation Alerts] Add module

--- a/newrelic/metric-stream/newrelic.tf
+++ b/newrelic/metric-stream/newrelic.tf
@@ -1,10 +1,3 @@
-resource "newrelic_cloud_aws_link_account" "default" {
-  arn                    = aws_iam_role.newrelic_integration_role.arn
-  metric_collection_mode = "PUSH"
-  name                   = var.newrelic_aws_account_name
-  account_id             = var.newrelic_account_id
-}
-
 resource "aws_iam_role" "newrelic_integration_role" {
   name               = "${var.name_prefix}-newrelic-integration-role"
   assume_role_policy = data.aws_iam_policy_document.newrelic_integration_assume_role.json

--- a/newrelic/metric-stream/variables.tf
+++ b/newrelic/metric-stream/variables.tf
@@ -18,11 +18,6 @@ variable "newrelic_access_key" {
   description = "The new relic access key."
 }
 
-variable "newrelic_aws_account_name" {
-  type        = string
-  description = "Nickname for AWS account in New Relic."
-}
-
 variable "newrelic_account_id" {
   type        = string
   description = "The account number for the New Relic account."

--- a/newrelic/metric-stream/versions.tf
+++ b/newrelic/metric-stream/versions.tf
@@ -8,9 +8,5 @@ terraform {
       version = ">= 4.67"
     }
 
-    newrelic = {
-      source  = "newrelic/newrelic"
-      version = ">= 2.44"
-    }
   }
 }


### PR DESCRIPTION
We don't really want to mix New Relic and AWS resources in the same module because authenticating these two platforms is pretty different in an automated environment