### PR TITLE
DP-34838: Add instance_tags variable to jumpbox module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.103] - 2024-09-12
+
+- [Jump Box] - Add `instance_tags` variable.
+
 ## [1.0.102] - 2024-09-02
 
 - [RDS] Update module to enable AWS-managed master passwords

--- a/jump-box/README.md
+++ b/jump-box/README.md
@@ -121,6 +121,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_ami"></a> [ami](#input\_ami) | The ami to use for the jump box. If the SSM Agent is not already installed on the ami, it should be installed through the user\_data variable. | `string` | n/a | yes |
+| <a name="input_instance_tags"></a> [instance\_tags](#input\_instance\_tags) | Additional tags to apply to the EC2 instance. | `map(string)` | `{}` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The instance type to use for the instance. | `string` | `"t4g.nano"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to use for the instance. | `string` | n/a | yes |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | The VPC subnet to launch the instance in. | `string` | n/a | yes |

--- a/jump-box/main.tf
+++ b/jump-box/main.tf
@@ -59,7 +59,10 @@ resource "aws_instance" "this" {
     http_tokens = "required"
   }
 
-  tags = {
-    "Name" = "${var.name}"
-  }
+  tags = merge(
+    var.instance_tags,
+    {
+      "Name" = "${var.name}"
+    }
+  )
 }

--- a/jump-box/variables.tf
+++ b/jump-box/variables.tf
@@ -24,6 +24,12 @@ variable "instance_type" {
   default     = "t4g.nano"
 }
 
+variable "instance_tags" {
+  type        = map(string)
+  description = "Additional tags to apply to the EC2 instance."
+  default     = {}
+}
+
 variable "volume_size" {
   type        = number
   description = "Size of the root volume in gibibytes."


### PR DESCRIPTION
I need to be able to apply the instance specific tags (`os`, `Patch Group`, `platform`) to the jump box, but I don't want to apply them to all of the resources in the module.