### PR TITLE
DP-34877: update synthetics certificate alert with required params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [1.0.103] - 2024-09-12
 
+- [New Relic/Synthetics Certificate Alert] - Add required parameters to `newrelic` Synthetics monitor resource
+
+## [1.0.103] - 2024-09-12
+
 - [Jump Box] - Add `instance_tags` variable.
 
 ## [1.0.102] - 2024-09-02

--- a/newrelic/synthetics-certificate-alert/main.tf
+++ b/newrelic/synthetics-certificate-alert/main.tf
@@ -17,6 +17,8 @@ resource "newrelic_synthetics_cert_check_monitor" "monitor" {
   certificate_expiration = var.certificate_expiration
   domain                 = var.domain
   locations_public       = var.locations
+  runtime_type           = "NODE_API"
+  runtime_type_version   = "16.10"
 
   dynamic "tag" {
     for_each = var.tags

--- a/newrelic/synthetics-certificate-alert/versions.tf
+++ b/newrelic/synthetics-certificate-alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     newrelic = {
       source  = "newrelic/newrelic"
-      version = ">= 2.44"
+      version = ">= 3.34"
     }
   }
 }

--- a/rdsinstance/variables.tf
+++ b/rdsinstance/variables.tf
@@ -194,13 +194,13 @@ variable "ca_cert_identifier" {
 }
 
 variable "manage_master_user_password" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Enables management of the master password with Secrets Manager"
 }
 
 variable "master_user_secret_kms_key_id" {
-  type = string
-  default = null
+  type        = string
+  default     = null
   description = "Specifies a custom KMS key used to encrypt/decrypt master password."
 }


### PR DESCRIPTION
The `newrelic` provider has shelved node10 (the default) as a valid runtime for synthetics certificate check monitors, which makes pretty obvious sense. So, we now have to explicitly upgrade the runtime to node16.

The NR docs are pretty wordy, but you can read the relevant stuff here: https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/synthetics_legacy_runtime_eol_migration_guide#syncing-updates-made-to-monitors-in-the-legacy-runtime-made-via-the-runtime-upgrades-ui-with-terraform-configuration