### PR TITLE
DP-36015: update lambda code to use both Public lambda function, and ALB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.108] - 2024-12-18
+
+- [Github-To-Teams]
+  - Update Lambda to use body from both public entrypoint and routing from ALB
+
 ## [1.0.107] - 2024-11-05
 
 - [Maintenance Calendar]

--- a/webhook-converters/github-to-teams/lambda/src/lambda.ts
+++ b/webhook-converters/github-to-teams/lambda/src/lambda.ts
@@ -13,7 +13,7 @@ const handler = async (event: APIGatewayProxyEventV2): Promise<APIGatewayProxyRe
   logger.debug('Config: ', config);
 
   // Validate the token passed in the path before anything else.
-  const tokenInput = event.rawPath.slice(1);
+  const tokenInput = event.rawPath ? event.rawPath.slice(1) : event.path.slice(1);
   logger.debug('Validating the token: ', tokenInput);
   const isTokenValid = validateToken({
     key: config.token,


### PR DESCRIPTION
When github webhook pushes code via ALB endpoint, is sends path details as `path` when using public endpoint uses `rawPath`