### PR TITLE
DP-30891: Return integration role ARN from NR metric stream module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.109] - 2025-01-09
+
+- [New Relic]
+  - Output integration role ARN from `metric-stream` submodule
+
 ## [1.0.108] - 2024-12-18
 
 - [Github-To-Teams]

--- a/newrelic/metric-stream/output.tf
+++ b/newrelic/metric-stream/output.tf
@@ -1,0 +1,8 @@
+output "integration_role_arn" {
+  description = <<EOF
+    The ARN of the IAM role created used by New Relic to access metric stream data. Reference
+    this when creating a newrelic_cloud_aws_link_account resource:
+    https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/cloud_aws_link_account
+  EOF
+  value = aws_iam_role.newrelic_integration_role.arn
+}


### PR DESCRIPTION
We need this ARN on the New Relic side when creating this thingamabob: https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/cloud_aws_link_account