### PR TITLE
Correct apply errors we're seeing in DS-Infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.113] - 2025-04-17
+
+- [golden-ami-builder]
+  - Use `create_before_destroy` for image recipes in order to get around resource dependency issues
+  - Filter out invalid resource tags
+
 ## [1.0.112] - 2025-04-03
 
 - [gha-role]

--- a/golden-ami-builder/main.tf
+++ b/golden-ami-builder/main.tf
@@ -167,9 +167,9 @@ resource "aws_imagebuilder_infrastructure_configuration" "golden_ami" {
   resource_tags = merge(
     var.instance_tags,
     {
-      # 'CreatedBy' and 'Ec2ImageBuilderArn' are reserved tags for instances created by
-      # Image Builder. Trying to provide either will kill deployments
-      for k, v in var.tags : k => v if !contains(["createdby", "ec2imagebuilderarn"], lower(k))
+      # The following are reserved tags for instances created by
+      # Image Builder. Trying to use any of them will kill deployments
+      for k, v in var.tags : k => v if !contains(["createdby", "ec2imagebuilderarn", "patch group", "patchgroup"], lower(k))
     }
   )
   tags = var.tags
@@ -294,6 +294,10 @@ resource "aws_imagebuilder_image_recipe" "golden_ami" {
   version      = "1.0.0"
 
   tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_imagebuilder_image_pipeline" "golden_ami" {

--- a/maintenance-calendar/modules/ecs_scans/lambda/package-lock.json
+++ b/maintenance-calendar/modules/ecs_scans/lambda/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@js-joda/timezone": "^2.3.0",
         "assert": "^2.1.0",
         "pino": "^8.16.2"
       },
@@ -24,7 +25,7 @@
         "@types/node": "^20.9.1",
         "archiver": "^5.3.1",
         "esbuild": "^0.17.14",
-        "prettier": "^3.1.0",
+        "prettier": "^3.3.3",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.5"
       }
@@ -1226,6 +1227,20 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@js-joda/core": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.5.tgz",
+      "integrity": "sha512-3zwefSMwHpu8iVUW8YYz227sIv6UFqO31p1Bf1ZH/Vom7CmNyUsXjDBlnNzcuhmOL1XfxZ3nvND42kR23XlbcQ==",
+      "peer": true
+    },
+    "node_modules/@js-joda/timezone": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@js-joda/timezone/-/timezone-2.22.0.tgz",
+      "integrity": "sha512-9UNXxEztbcofD6XvV7xPrbzB2nE/AWaHr/XfugRZgVqg2vCZOVPnD8QI7GW164EFIWMw0c97Gs6STJ5dh0J99Q==",
+      "peerDependencies": {
+        "@js-joda/core": ">=1.11.0"
       }
     },
     "node_modules/@smithy/abort-controller": {
@@ -2788,9 +2803,9 @@
       "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
     },
     "node_modules/prettier": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
-      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"


### PR DESCRIPTION
https://github.com/massgov/DS-Infrastructure/actions/runs/14528395392/job/40763992520

```
Error: deleting Image Builder Image Recipe (arn:aws:imagebuilder:us-east-1:748039698304:image-recipe/itd-mgt-ssr-golden-aws-linux-2-recipe/1.0.0): operation error imagebuilder: DeleteImageRecipe, https response error StatusCode: 400, RequestID: 8f6887e1-f7c2-43b6-a161-4b496dcade57, ResourceDependencyException: Resource dependency error: The resource ARN 'arn:aws:imagebuilder:us-east-1:748039698304:image-recipe/itd-mgt-ssr-golden-aws-linux-2-recipe/1.0.0' has other resources depended on it.
```

Looks to be identical to this: https://github.com/hashicorp/terraform-provider-aws/issues/22127

---
```
Error: updating Image Builder Infrastructure Configuration (arn:aws:imagebuilder:us-east-1:748039698304:infrastructure-configuration/itd-mgt-ssr-golden-aws-linux-2-infrastructure-configuration): operation error imagebuilder: UpdateInfrastructureConfiguration, https response error StatusCode: 400, RequestID: 350637b9-3d0b-43e9-8e23-d45c6e67916b, api error InvalidParameterValueException: The value supplied for parameter 'resourceTags' is not valid. resourceTags must not contain {'Patch Group'} properties
```
Sort of annoying that [image builder docs](https://docs.aws.amazon.com/imagebuilder/latest/userguide/tag-resources.html) don't mention `Patch Group` as a reserved tag, but I guess it is one.