### PR TITLE
DP-37955: Golden Image & instance tagging

### DIFF
--- a/golden-ami-builder/main.tf
+++ b/golden-ami-builder/main.tf
@@ -1,7 +1,7 @@
 data "aws_caller_identity" "current" {}
 data "aws_iam_account_alias" "current" {}
 data "aws_region" "current" {}
-
+data "aws_default_tags" "current" {}
 data "aws_kms_key" "volume_key" {
   key_id = var.volume_key_alias
 }
@@ -10,6 +10,7 @@ locals {
   account_id    = data.aws_caller_identity.current.account_id
   account_alias = data.aws_iam_account_alias.current.account_alias
   region        = data.aws_region.current.name
+  required_tags = data.aws_default_tags.current.tags != {} ? merge(var.instance_tags, data.aws_default_tags.current.tags) : var.instance_tags
 
   # Bucket names can be max 63 characters log
   logs_bucket_suffix = "golden-ami-image-builder-logs"
@@ -165,14 +166,14 @@ resource "aws_imagebuilder_infrastructure_configuration" "golden_ami" {
   }
 
   resource_tags = merge(
-    var.instance_tags,
+    local.required_tags,
     {
       # The following are reserved tags for instances created by
       # Image Builder. Trying to use any of them will kill deployments
       for k, v in var.tags : k => v if !contains(["createdby", "ec2imagebuilderarn", "patch group", "patchgroup"], lower(k))
     }
   )
-  tags = var.tags
+  tags = coalesce(var.tags, {})
 }
 
 resource "aws_imagebuilder_component" "download_and_install_cortex_xdr" {

--- a/golden-ami-builder/main.tf
+++ b/golden-ami-builder/main.tf
@@ -173,7 +173,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "golden_ami" {
       for k, v in var.tags : k => v if !contains(["createdby", "ec2imagebuilderarn", "patch group", "patchgroup"], lower(k))
     }
   )
-  tags = coalesce(var.tags, {})
+  tags = var.tags
 }
 
 resource "aws_imagebuilder_component" "download_and_install_cortex_xdr" {

--- a/golden-ami-builder/main.tf
+++ b/golden-ami-builder/main.tf
@@ -165,8 +165,9 @@ resource "aws_imagebuilder_infrastructure_configuration" "golden_ami" {
     }
   }
 
-  resource_tags = merge(
-    local.required_tags,
+  resource_tags = merge({
+    for k, v in local.required_tags : k => v if !contains(["createdby", "ec2imagebuilderarn", "patch group", "patchgroup"], lower(k))
+    },
     {
       # The following are reserved tags for instances created by
       # Image Builder. Trying to use any of them will kill deployments

--- a/golden-ami-builder/variables.tf
+++ b/golden-ami-builder/variables.tf
@@ -56,5 +56,4 @@ variable "tags" {
     expected; make sure to explicitly pass in all desired tags (default: {})
   EOF
   type        = map(string)
-  default     = {}
 }

--- a/newrelic/metric-stream/output.tf
+++ b/newrelic/metric-stream/output.tf
@@ -4,5 +4,5 @@ output "integration_role_arn" {
     this when creating a newrelic_cloud_aws_link_account resource:
     https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/cloud_aws_link_account
   EOF
-  value = aws_iam_role.newrelic_integration_role.arn
+  value       = aws_iam_role.newrelic_integration_role.arn
 }


### PR DESCRIPTION
- Uses AWS provider default variables merged with instance variables for required resource tagging.
- removed default of blank/null map for var.tags, since this should be a requirement from the root module/repo and values should always be passed.