### PR TITLE
DP-39523 : exclude the latest newrelic version due to breaking changes.

### DIFF
--- a/newrelic/nrql-alert/versions.tf
+++ b/newrelic/nrql-alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     newrelic = {
       source  = "newrelic/newrelic"
-      version = ">= 2.44"
+      version = ">= 2.44, < 3.62"
     }
   }
 }


### PR DESCRIPTION
NewRelic rolled out a new terraform provider version that causes errors due to not having a parameter that is documented as 'optionable' , but the error is also unclear.  Due to this we should refrain from using v3.62.0 until the provider issue is fixed.