### PR TITLE
DP-39540: remove needless provider constraints from tagging module

### DIFF
--- a/tagging/versions.tf
+++ b/tagging/versions.tf
@@ -1,9 +1,3 @@
 terraform {
   required_version = ">= 0.13"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.87.0"
-    }
-  }
 }


### PR DESCRIPTION
I think I probably copy-pasted `versions.tf` from a different module and didn't check my work. None of what's going on inside the tagging module requires the `aws` provider, and setting version constraints leads to erroneous incompatibilities in consumer code ([like this](https://github.com/massgov/mdo-pdg/actions/runs/15536305484/job/43736039474?pr=1260))