### PR TITLE
Bugfix to support separate generation and application of terraform plan files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.117] - 2025-05-15
+
+- [Github-To-Teams] Bugfix to support separate generation and application of terraform plan files
+- [Entrypoint Monitor] Bugfix to support separate generation and application of terraform plan files
+
 ## [1.x] - 2025-06-26
 
 - [Maintenance Calendar]

--- a/entrypoint-monitoring/main.tf
+++ b/entrypoint-monitoring/main.tf
@@ -7,7 +7,7 @@ locals {
   aws_account_id = data.aws_caller_identity.current.account_id
 }
 
-data "archive_file" "monitor_package" {
+resource "archive_file" "monitor_package" {
   type        = "zip"
   source_file = "${path.module}/lambda/dist/lambda.js"
   output_path = "${path.module}/package/lambda.zip"

--- a/webhook-converters/github-to-teams/main.tf
+++ b/webhook-converters/github-to-teams/main.tf
@@ -7,7 +7,7 @@ locals {
   aws_account_id = data.aws_caller_identity.current.account_id
 }
 
-data "archive_file" "lambda_package" {
+resource "archive_file" "lambda_package" {
   type        = "zip"
   source_file = "${path.module}/lambda/dist/lambda.js"
   output_path = "${path.module}/package/lambda.zip"


### PR DESCRIPTION
The entrypoint monitor and github-to-teams modules have been using the `archive_file` data block to package code for use as a Lambda function. While this works fine under a normal `terraform apply`, it leads to file-not-found errors when we save a plan file and apply it later. The `archive_file` data source docs explain:

> Generates an archive from content, a file, or directory of files. The archive is built during the terraform plan, so you must persist the archive through to the terraform apply.

https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file 

The solution is to simple switch from a `data` block to a `resource` block.