### PR TITLE
DP-40059: Upgrade maintenance calendar script(s) to python3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.x] - 2025-07-23
+
+- [Maintenance Calendar]
+  - [RDS Snapshots] upgrade all usages of `aws:executeScript` to python 3.11
+
 ## [1.0.117] - 2025-05-15
 
 - [Github-To-Teams] Bugfix to support separate generation and application of terraform plan files

--- a/maintenance-calendar/modules/rds_snapshots/templates/clean_up_rds_snapshots.yml
+++ b/maintenance-calendar/modules/rds_snapshots/templates/clean_up_rds_snapshots.yml
@@ -36,7 +36,7 @@ mainSteps:
     onFailure: 'step:AlertOnError'
     onCancel: Abort
     inputs:
-      Runtime: python3.8
+      Runtime: python3.11
       Handler: clean_up_db_snapshots
       Script: |-
         import boto3


### PR DESCRIPTION
We received a warning "regarding end of support for Python versions 3.6, 3.7, 3.8 and 3.9 for ‘aws:executeScript’ actions in AWS Systems Manager Automation." Pretty sure the resolution is just this simple.