### PR TITLE
DP-41663 : add in S3_bucket module

### DIFF
--- a/s3_bucket/README.md
+++ b/s3_bucket/README.md
@@ -1,0 +1,32 @@
+# Overview
+
+Sets up S3 Bucket.
+
+## Setup
+
+Add the following content in the file `main.tf` from the root folder:
+
+```terraform
+provider "aws" {
+    region = "us-east-1"
+}
+
+module "an_s3_bucket" {
+    source                  = "./modules/s3_bucket"
+
+    bucket_region           = "us-west-2"
+    bucket_name             = "my-practice-bucket"
+    bucket_tags             = {
+               Tag1    = "something1"
+               Tag2    = "something2"
+    }
+}
+
+output "full_bucket_name" {
+    value = "${module.an_s3_bucket.full_bucket_name}"
+}
+```
+
+## Outputs
+
+`full_bucket_name` - full bucket name including the random number

--- a/s3_bucket/README.md
+++ b/s3_bucket/README.md
@@ -1,32 +1,42 @@
 # Overview
 
-Sets up S3 Bucket.
+Sets up S3 Bucket, with many features/switches and default bucket policy for SSL/TLS only (if default not changed.)
 
 ## Setup
 
-Add the following content in the file `main.tf` from the root folder:
+Add the following content in the file `main.tf` from the root folder or in your own root project folders:
 
 ```terraform
+
+# add to versions/providers.tf
 provider "aws" {
     region = "us-east-1"
 }
 
+# add to main.tf
 module "an_s3_bucket" {
     source                  = "./modules/s3_bucket"
 
-    bucket_region           = "us-west-2"
-    bucket_name             = "my-practice-bucket"
+    bucket_region           = "us-east-1"
+    bucket_name             = "my-super-secure-bucket-thingamabob"
     bucket_tags             = {
+        # add below OR add provider default/module tag variables.
                Tag1    = "something1"
                Tag2    = "something2"
     }
 }
 
+# add to outputs.tf
 output "full_bucket_name" {
     value = "${module.an_s3_bucket.full_bucket_name}"
+}
+
+output "full_bucket_arn" {
+  value = aws_s3_bucket.my_bucket.arn
 }
 ```
 
 ## Outputs
 
 `full_bucket_name` - full bucket name including the random number
+`full_bucket_arn`  - full bucket arn

--- a/s3_bucket/main.tf
+++ b/s3_bucket/main.tf
@@ -15,8 +15,17 @@ locals {
 resource "aws_kms_key" "s3_key" {
   count                   = (var.kms_key_arn == "" && var.kms_encrypted) ? 1 : 0
   description             = "This key is used to encrypt bucket objects in ${local.bucket_root_name} and ${local.bucket_root_name}-logs"
-  deletion_window_in_days = 15 # Length of time the key will be retained when a deletion is scheduled.
+  deletion_window_in_days = var.deletion_window_in_days # Length of time the key will be retained when a deletion is scheduled.
   enable_key_rotation     = true
+
+  dynamic "policy" {
+    for_each = var.kms_policy != "" ? [1] : []
+    content {
+      # Use the provided policy if one is provided
+      # otherwise the default policy created by AWS will be used
+      policy = var.kms_policy
+    }
+  }
 }
 
 resource "aws_kms_alias" "s3_key_alias" {

--- a/s3_bucket/main.tf
+++ b/s3_bucket/main.tf
@@ -80,18 +80,18 @@ resource "aws_s3_bucket_acl" "default_bucket_acl" {
   acl    = "private"
 }
 
-# Only create if var.non_ssl_requests = false (the default)
+# Only create if var.permit_non_ssl_requests = false (the default)
 resource "aws_s3_bucket_policy" "default_bucket_policy" {
-  count  = var.non_ssl_requests ? 0 : 1
+  count  = var.permit_non_ssl_requests ? 0 : 1
   bucket = aws_s3_bucket.default_bucket.id
   policy = data.aws_iam_policy_document.default_bucket_policy.json
 }
 
-# Only used if var.non_ssl_requests = true and there is a custom policy passed in var.custom_policy
-resource "aws_s3_bucket_policy" "non_ssl_requests_policy" {
-  count  = var.non_ssl_requests == true && length(var.custom_policy) > 0 ? 1 : 0
+# Only used if var.permit_non_ssl_requests = true and there is a custom policy passed in var.custom_policy
+resource "aws_s3_bucket_policy" "permit_non_ssl_requests" {
+  count  = var.permit_non_ssl_requests == true && length(var.custom_policy) > 0 ? 1 : 0
   bucket = aws_s3_bucket.default_bucket.id
-  policy = data.aws_iam_policy_document.non_ssl_requests_policy[0].json
+  policy = data.aws_iam_policy_document.permit_non_ssl_requests[0].json
 }
 
 # Only used if var.kms_encrypted = true
@@ -100,7 +100,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "s3_sse_config" {
   bucket = aws_s3_bucket.default_bucket.bucket
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = (var.kms_key_arn == "" && var.kms_encrypted) ? aws_kms_key.s3_key[0].arn : var.kms_key_arn
+      kms_master_key_id = (var.kms_key_arn == "" && var.kms_encrypted) ? aws_kms_key.s3_key[0].arn : data.aws_kms_key.s3_key_arn.id[0]
       sse_algorithm     = "aws:kms"
     }
   }
@@ -126,9 +126,9 @@ resource "aws_s3_bucket_versioning" "default_bucket_versioning" {
   }
 }
 
-# Only used if var.non_ssl_requests = true and there is a custom policy passed in var.custom_policy
-data "aws_iam_policy_document" "non_ssl_requests_policy" {
-  count = var.non_ssl_requests == true && length(var.custom_policy) > 0 ? 1 : 0
+# Only used if var.permit_non_ssl_requests = true and there is a custom policy passed in var.custom_policy
+data "aws_iam_policy_document" "permit_non_ssl_requests" {
+  count = var.permit_non_ssl_requests == true && length(var.custom_policy) > 0 ? 1 : 0
   # Optional extra statement when var.custom_policy != ""
   dynamic "statement" {
     for_each = var.custom_policy != "" ? [jsondecode(var.custom_policy)] : []
@@ -166,9 +166,9 @@ data "aws_iam_policy_document" "non_ssl_requests_policy" {
   }
 }
 
-# Only used if var.non_ssl_requests = false (the default)
+# Only used if var.permit_non_ssl_requests = false (the default)
 data "aws_iam_policy_document" "default_bucket_policy" {
-  count = var.non_ssl_requests ? 0 : 1
+  count = var.permit_non_ssl_requests ? 0 : 1
   # HTTPS only for all actions on this bucket
   statement {
     sid    = "DenyInsecureTransport"

--- a/s3_bucket/main.tf
+++ b/s3_bucket/main.tf
@@ -64,14 +64,25 @@ resource "aws_s3_bucket" "default_bucket" {
   force_destroy = var.important ? false : true
 }
 
+# Only create if var.public = false (the default)
 resource "aws_s3_bucket_acl" "default_bucket_acl" {
+  count  = var.public ? 0 : 1
   bucket = aws_s3_bucket.default_bucket.id
   acl    = "private"
 }
 
+# Only create if var.non_ssl_requests = false (the default)
 resource "aws_s3_bucket_policy" "default_bucket_policy" {
+  count  = var.non_ssl_requests ? 0 : 1
   bucket = aws_s3_bucket.default_bucket.id
   policy = data.aws_iam_policy_document.default_bucket_policy.json
+}
+
+# Only used if var.non_ssl_requests = true and there is a custom policy passed in var.custom_policy
+resource "aws_s3_bucket_policy" "non_ssl_requests_policy" {
+  count  = var.non_ssl_requests == true && length(var.custom_policy) > 0 ? 1 : 0
+  bucket = aws_s3_bucket.default_bucket.id
+  policy = data.aws_iam_policy_document.non_ssl_requests_policy[0].json
 }
 
 # Only used if var.kms_encrypted = true
@@ -106,7 +117,49 @@ resource "aws_s3_bucket_versioning" "default_bucket_versioning" {
   }
 }
 
+# Only used if var.non_ssl_requests = true and there is a custom policy passed in var.custom_policy
+data "aws_iam_policy_document" "non_ssl_requests_policy" {
+  count = var.non_ssl_requests == true && length(var.custom_policy) > 0 ? 1 : 0
+  # Optional extra statement when var.custom_policy != ""
+  dynamic "statement" {
+    for_each = var.custom_policy != "" ? [jsondecode(var.custom_policy)] : []
+    content {
+      sid       = try(statement.value.sid, null)
+      effect    = statement.value.effect
+      actions   = statement.value.actions
+      resources = statement.value.resources
+
+      # principals can be one object OR a list of objects
+      dynamic "principals" {
+        for_each = contains(keys(statement.value), "principals") ? (can(statement.value.principals[0]) ? statement.value.principals :
+        [statement.value.principals]) : []
+
+        content {
+          type        = principals.value.type
+          identifiers = principals.value.identifiers
+        }
+      }
+      # condition can be single condition or list of conditions
+      dynamic "condition" {
+        for_each = contains(keys(statement.value), "conditions") ? statement.value.conditions : (
+          contains(keys(statement.value), "condition")
+          ? [statement.value.condition]
+          : []
+        )
+
+        content {
+          test     = condition.value.test
+          variable = condition.value.variable
+          values   = condition.value.values
+        }
+      }
+    }
+  }
+}
+
+# Only used if var.non_ssl_requests = false (the default)
 data "aws_iam_policy_document" "default_bucket_policy" {
+  count = var.non_ssl_requests ? 0 : 1
   # HTTPS only for all actions on this bucket
   statement {
     sid    = "DenyInsecureTransport"

--- a/s3_bucket/main.tf
+++ b/s3_bucket/main.tf
@@ -69,6 +69,11 @@ resource "aws_s3_bucket_acl" "default_bucket_acl" {
   acl    = "private"
 }
 
+resource "aws_s3_bucket_policy" "default_bucket_policy" {
+  bucket = aws_s3_bucket.default_bucket.id
+  policy = data.aws_iam_policy_document.default_bucket_policy.json
+}
+
 # Only used if var.kms_encrypted = true
 resource "aws_s3_bucket_server_side_encryption_configuration" "s3_sse_config" {
   count  = var.kms_encrypted ? 1 : 0
@@ -101,13 +106,17 @@ resource "aws_s3_bucket_versioning" "default_bucket_versioning" {
   }
 }
 
-# Default bucket policy to deny unencrypted (non-SSL) requests
 data "aws_iam_policy_document" "default_bucket_policy" {
+  # HTTPS only for all actions on this bucket
   statement {
-    sid       = "DenyInsecureTransport"
-    effect    = "Deny"
-    actions   = ["s3:*"]
-    resources = ["${aws_s3_bucket.default_bucket.arn}/*"]
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.default_bucket.arn,
+      "${aws_s3_bucket.default_bucket.arn}/*",
+    ]
 
     principals {
       type        = "*"
@@ -121,25 +130,34 @@ data "aws_iam_policy_document" "default_bucket_policy" {
     }
   }
 
-  # dynamic extra statement only if var.custom_policy is not empty
+  # Optional extra statement when var.custom_policy != ""
   dynamic "statement" {
     for_each = var.custom_policy != "" ? [jsondecode(var.custom_policy)] : []
     content {
-      sid       = statement.value.sid
+      sid       = try(statement.value.sid, null)
       effect    = statement.value.effect
       actions   = statement.value.actions
       resources = statement.value.resources
 
+      # principals can be one object OR a list of objects
       dynamic "principals" {
-        for_each = lookup(statement.value, "principals", [])
+        for_each = contains(keys(statement.value), "principals") ? (can(statement.value.principals[0]) ? statement.value.principals :
+        [statement.value.principals]) : []
+
         content {
           type        = principals.value.type
           identifiers = principals.value.identifiers
         }
       }
 
+      # condition can be single condition or list of conditions
       dynamic "condition" {
-        for_each = lookup(statement.value, "conditions", lookup(statement.value, "condition", []))
+        for_each = contains(keys(statement.value), "conditions") ? statement.value.conditions : (
+          contains(keys(statement.value), "condition")
+          ? [statement.value.condition]
+          : []
+        )
+
         content {
           test     = condition.value.test
           variable = condition.value.variable

--- a/s3_bucket/main.tf
+++ b/s3_bucket/main.tf
@@ -36,7 +36,7 @@ resource "aws_kms_alias" "s3_key_alias" {
 
 data "aws_kms_key" "s3_key_arn" {
   count  = var.kms_encrypted && var.kms_key_arn != "" ? 1 : 0
-  key_id = (var.kms_key_arn == "" && var.kms_encrypted) ? aws_kms_key.s3_key[0].arn : var.kms_key_arn
+  key_id = var.kms_key_arn
 }
 
 #############################################################################

--- a/s3_bucket/main.tf
+++ b/s3_bucket/main.tf
@@ -7,7 +7,11 @@ locals {
   bucket_root_name = var.guarantee_uniqueness ? "${var.bucket_name}-${random_id.bucket_id.dec}" : var.bucket_name
 }
 
-# Only used if var.kms_encrypted = true
+#############################################################################
+# KMS Key for server-side encryption of bucket objects
+#############################################################################
+
+# Only create if var.kms_encrypted = true
 resource "aws_kms_key" "s3_key" {
   count                   = (var.kms_key_arn == "" && var.kms_encrypted) ? 1 : 0
   description             = "This key is used to encrypt bucket objects in ${local.bucket_root_name} and ${local.bucket_root_name}-logs"
@@ -26,9 +30,21 @@ data "aws_kms_key" "s3_key_arn" {
   key_id = (var.kms_key_arn == "" && var.kms_encrypted) ? aws_kms_key.s3_key[0].arn : var.kms_key_arn
 }
 
+#############################################################################
+# Logging bucket (if enabled)
+#############################################################################
+
+# Only create if var.enable_logging = true
 resource "aws_s3_bucket" "log_bucket" {
   count  = var.enable_logging ? 1 : 0
   bucket = "${local.bucket_root_name}-logs"
+}
+
+resource "aws_s3_bucket_logging" "default_bucket_logging" {
+  count         = var.enable_logging ? 1 : 0
+  bucket        = aws_s3_bucket.default_bucket.id
+  target_bucket = aws_s3_bucket.log_bucket.id
+  target_prefix = var.log_prefix
 }
 
 resource "aws_s3_bucket_acl" "log_bucket_acl" {
@@ -36,10 +52,27 @@ resource "aws_s3_bucket_acl" "log_bucket_acl" {
   acl    = "log-delivery-write"
 }
 
+
+#############################################################################
+# Default S3 Bucket
+#############################################################################
+
+# If bucket is NOT important, force_destroy = true; force-destroyed bucket contents are not recoverable!
+resource "aws_s3_bucket" "default_bucket" {
+  bucket        = local.bucket_root_name
+  tags          = var.bucket_tags
+  force_destroy = var.important ? false : true
+}
+
+resource "aws_s3_bucket_acl" "default_bucket_acl" {
+  bucket = aws_s3_bucket.default_bucket.id
+  acl    = "private"
+}
+
 # Only used if var.kms_encrypted = true
 resource "aws_s3_bucket_server_side_encryption_configuration" "s3_sse_config" {
   count  = var.kms_encrypted ? 1 : 0
-  bucket = aws_s3_bucket.my_bucket.bucket
+  bucket = aws_s3_bucket.default_bucket.bucket
   rule {
     apply_server_side_encryption_by_default {
       kms_master_key_id = (var.kms_key_arn == "" && var.kms_encrypted) ? aws_kms_key.s3_key[0].arn : var.kms_key_arn
@@ -48,9 +81,10 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "s3_sse_config" {
   }
 }
 
+# Only used if var.kms_encrypted = false (which is the default value)
 resource "aws_s3_bucket_server_side_encryption_configuration" "s3_aes_config" {
   count  = var.kms_encrypted ? 0 : 1
-  bucket = aws_s3_bucket.my_bucket.bucket
+  bucket = aws_s3_bucket.default_bucket.bucket
   rule {
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
@@ -58,37 +92,60 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "s3_aes_config" {
   }
 }
 
-resource "aws_s3_bucket" "my_bucket" {
-  bucket        = local.bucket_root_name
-  tags          = var.bucket_tags
-  force_destroy = var.important
-  # If bucket is not important, force_destroy = true; force-destroyed bucket contents are not recoverable!
-}
-
-resource "aws_s3_bucket_acl" "my_bucket_acl" {
-  bucket = aws_s3_bucket.my_bucket.id
-  acl    = "private"
-}
-
-
 # If bucket is important, turn on versioning
-resource "aws_s3_bucket_versioning" "my_bucket_versioning" {
-  bucket = aws_s3_bucket.my_bucket.id
+resource "aws_s3_bucket_versioning" "default_bucket_versioning" {
+  bucket = aws_s3_bucket.default_bucket.id
   count  = var.important ? 1 : 0
   versioning_configuration {
     status = "Enabled"
   }
 }
 
-resource "aws_s3_bucket_logging" "my_bucket_logging" {
-  count         = var.enable_logging ? 1 : 0
-  bucket        = aws_s3_bucket.my_bucket.id
-  target_bucket = aws_s3_bucket.log_bucket.id
-  target_prefix = var.log_prefix
+# Default bucket policy to deny unencrypted (non-SSL) requests
+data "aws_iam_policy_document" "default_bucket_policy" {
+  statement {
+    sid       = "DenyInsecureTransport"
+    effect    = "Deny"
+    actions   = ["s3:*"]
+    resources = ["${aws_s3_bucket.default_bucket.arn}/*"]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+
+  # dynamic extra statement only if var.custom_policy is not empty
+  dynamic "statement" {
+    for_each = var.custom_policy != "" ? [jsondecode(var.custom_policy)] : []
+    content {
+      sid       = statement.value.sid
+      effect    = statement.value.effect
+      actions   = statement.value.actions
+      resources = statement.value.resources
+
+      dynamic "principals" {
+        for_each = lookup(statement.value, "principals", [])
+        content {
+          type        = principals.value.type
+          identifiers = principals.value.identifiers
+        }
+      }
+
+      dynamic "condition" {
+        for_each = lookup(statement.value, "conditions", lookup(statement.value, "condition", []))
+        content {
+          test     = condition.value.test
+          variable = condition.value.variable
+          values   = condition.value.values
+        }
+      }
+    }
+  }
 }
-
-
-##### IAM Policy to encrypt in transit (https)access to bucket #####
-
-
-##data "aws_iam_policy_document" "s3_bucket_policy" {

--- a/s3_bucket/main.tf
+++ b/s3_bucket/main.tf
@@ -1,0 +1,94 @@
+# Create a random id
+resource "random_id" "bucket_id" {
+  byte_length = 8
+}
+
+locals {
+  bucket_root_name = var.guarantee_uniqueness ? "${var.bucket_name}-${random_id.bucket_id.dec}" : var.bucket_name
+}
+
+# Only used if var.kms_encrypted = true
+resource "aws_kms_key" "s3_key" {
+  count                   = (var.kms_key_arn == "" && var.kms_encrypted) ? 1 : 0
+  description             = "This key is used to encrypt bucket objects in ${local.bucket_root_name} and ${local.bucket_root_name}-logs"
+  deletion_window_in_days = 15 # Length of time the key will be retained when a deletion is scheduled.
+  enable_key_rotation     = true
+}
+
+resource "aws_kms_alias" "s3_key_alias" {
+  count         = (var.kms_key_arn == "" && var.kms_encrypted) ? 1 : 0
+  name          = "alias/${local.bucket_root_name}"
+  target_key_id = aws_kms_key.s3_key[0].arn
+}
+
+data "aws_kms_key" "s3_key_arn" {
+  count  = var.kms_encrypted && var.kms_key_arn != "" ? 1 : 0
+  key_id = (var.kms_key_arn == "" && var.kms_encrypted) ? aws_kms_key.s3_key[0].arn : var.kms_key_arn
+}
+
+resource "aws_s3_bucket" "log_bucket" {
+  count  = var.enable_logging ? 1 : 0
+  bucket = "${local.bucket_root_name}-logs"
+}
+
+resource "aws_s3_bucket_acl" "log_bucket_acl" {
+  bucket = aws_s3_bucket.log_bucket.id
+  acl    = "log-delivery-write"
+}
+
+# Only used if var.kms_encrypted = true
+resource "aws_s3_bucket_server_side_encryption_configuration" "s3_sse_config" {
+  count  = var.kms_encrypted ? 1 : 0
+  bucket = aws_s3_bucket.my_bucket.bucket
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = (var.kms_key_arn == "" && var.kms_encrypted) ? aws_kms_key.s3_key[0].arn : var.kms_key_arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "s3_aes_config" {
+  count  = var.kms_encrypted ? 0 : 1
+  bucket = aws_s3_bucket.my_bucket.bucket
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "my_bucket" {
+  bucket        = local.bucket_root_name
+  tags          = var.bucket_tags
+  force_destroy = var.important
+  # If bucket is not important, force_destroy = true; force-destroyed bucket contents are not recoverable!
+}
+
+resource "aws_s3_bucket_acl" "my_bucket_acl" {
+  bucket = aws_s3_bucket.my_bucket.id
+  acl    = "private"
+}
+
+
+# If bucket is important, turn on versioning
+resource "aws_s3_bucket_versioning" "my_bucket_versioning" {
+  bucket = aws_s3_bucket.my_bucket.id
+  count  = var.important ? 1 : 0
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_logging" "my_bucket_logging" {
+  count         = var.enable_logging ? 1 : 0
+  bucket        = aws_s3_bucket.my_bucket.id
+  target_bucket = aws_s3_bucket.log_bucket.id
+  target_prefix = var.log_prefix
+}
+
+
+##### IAM Policy to encrypt in transit (https)access to bucket #####
+
+
+##data "aws_iam_policy_document" "s3_bucket_policy" {

--- a/s3_bucket/outputs.tf
+++ b/s3_bucket/outputs.tf
@@ -1,7 +1,19 @@
 output "full_bucket_name" {
-  value = aws_s3_bucket.my_bucket.id
+  value = aws_s3_bucket.default_bucket.id
 }
 
 output "full_bucket_arn" {
-  value = aws_s3_bucket.my_bucket.arn
+  value = aws_s3_bucket.default_bucket.arn
+}
+
+output "log_bucket_name" {
+  value = aws_s3_bucket.log_bucket.id
+}
+
+output "log_bucket_arn" {
+  value = aws_s3_bucket.log_bucket.arn
+}
+
+output "kms_key_arn" {
+  value = var.kms_encrypted ? (var.kms_key_arn != "" ? var.kms_key_arn : aws_kms_key.s3_key[0].arn) : ""
 }

--- a/s3_bucket/outputs.tf
+++ b/s3_bucket/outputs.tf
@@ -1,0 +1,7 @@
+output "full_bucket_name" {
+  value = aws_s3_bucket.my_bucket.id
+}
+
+output "full_bucket_arn" {
+  value = aws_s3_bucket.my_bucket.arn
+}

--- a/s3_bucket/variables.tf
+++ b/s3_bucket/variables.tf
@@ -1,0 +1,59 @@
+variable "bucket_name" {
+  type        = string
+  description = "Name of the backet (random numbers will be appended at the end)."
+  default     = "my-bucket"
+}
+
+variable "guarantee_uniqueness" {
+  type        = bool
+  description = "Append some random characters to the bucket name in order to guarantee global uniqueness?"
+  default     = true
+}
+
+variable "bucket_region" {
+  type        = string
+  description = "Location of the bucket, such as `us-west-2` or `ca-central-1`."
+  default     = "us-east-1"
+}
+
+variable "bucket_tags" {
+  type        = map(string)
+  description = "Optional tags for the bucket"
+  default     = {}
+}
+
+variable "kms_encrypted" {
+  type        = bool
+  description = "Should the bucket objects be server-side encrypted?"
+  default     = false
+}
+
+variable "kms_key_arn" {
+  type        = string
+  description = "Optional KMS Key ARN to use for S3 bucket encryption. If blank, and if var.encrypted == true, then this module will create a new KMS Key to encrypt the S3 bucket."
+  default     = ""
+}
+
+variable "important" {
+  type        = bool
+  description = "Should the bucket have versioning enabled, force_destroy disabled, and any other future protections due to its importance?"
+  default     = false
+}
+
+variable "public" {
+  type        = bool
+  description = "Should this bucket be publicly accessible? Default is false. CAUTION: Only things like CSS/JS assets for a public web site should ever be publicly accessible! Use locked-down/private S3 buckets by default!"
+  default     = false
+}
+
+variable "log_prefix" {
+  type        = string
+  description = "A prefix for all log object keys."
+  default     = "log/"
+}
+
+variable "enable_logging" {
+  type        = bool
+  description = "Should access logging be enabled for this bucket?"
+  default     = false
+}

--- a/s3_bucket/variables.tf
+++ b/s3_bucket/variables.tf
@@ -63,3 +63,9 @@ variable "custom_policy" {
   description = "Optional custom bucket policy in JSON (as a string). If this is provided, it will override the default policy that is created."
   default     = ""
 }
+
+variable "non_ssl_requests" {
+  type        = bool
+  description = "Allow non-SSL requests? Default is false (only allow SSL). CAUTION: Only disable SSL if you have a very good reason!"
+  default     = false
+}

--- a/s3_bucket/variables.tf
+++ b/s3_bucket/variables.tf
@@ -64,7 +64,7 @@ variable "custom_policy" {
   default     = ""
 }
 
-variable "non_ssl_requests" {
+variable "permit_non_ssl_requests" {
   type        = bool
   description = "Allow non-SSL requests? Default is false (only allow SSL). CAUTION: Only disable SSL if you have a very good reason!"
   default     = false

--- a/s3_bucket/variables.tf
+++ b/s3_bucket/variables.tf
@@ -1,13 +1,13 @@
 variable "bucket_name" {
   type        = string
   description = "Name of the backet (random numbers will be appended at the end)."
-  default     = "my-bucket"
+  default     = "default-bucket"
 }
 
 variable "guarantee_uniqueness" {
   type        = bool
   description = "Append some random characters to the bucket name in order to guarantee global uniqueness?"
-  default     = true
+  default     = false
 }
 
 variable "bucket_region" {
@@ -56,4 +56,10 @@ variable "enable_logging" {
   type        = bool
   description = "Should access logging be enabled for this bucket?"
   default     = false
+}
+
+variable "custom_policy" {
+  type        = string
+  description = "Optional custom bucket policy in JSON (as a string). If this is provided, it will override the default policy that is created."
+  default     = ""
 }

--- a/s3_bucket/variables.tf
+++ b/s3_bucket/variables.tf
@@ -69,3 +69,30 @@ variable "non_ssl_requests" {
   description = "Allow non-SSL requests? Default is false (only allow SSL). CAUTION: Only disable SSL if you have a very good reason!"
   default     = false
 }
+
+variable "kms_policy" {
+  type        = string
+  description = "The KMS key policy JSON"
+  default     = ""
+}
+
+# Note: AWS creates a default KMS key policy if you don't provide one.
+### example for kms_policy allowing full access to a specific account:
+#  kms_policy =  <<POLICY
+# {
+#   "Version": "2012-10-17",
+#   "Id": "default",
+#   "Statement": [
+#     {
+#       "Sid": "DefaultAllow",
+#       "Effect": "Allow",
+#       "Principal": {
+#         "AWS": "arn:aws:iam::123456789012:root"
+#       },
+#       "Action": "kms:*",
+#       "Resource": "*"
+#     }
+#   ]
+# }
+# POLICY
+# }

--- a/s3_bucket/variables.tf
+++ b/s3_bucket/variables.tf
@@ -76,6 +76,12 @@ variable "kms_policy" {
   default     = ""
 }
 
+variable "deletion_window_in_days" {
+  type        = number
+  description = "Length of time (in days) the KMS key will be retained when a deletion is scheduled. Only used if a new KMS key is created by this module."
+  default     = 30
+}
+
 # Note: AWS creates a default KMS key policy if you don't provide one.
 ### example for kms_policy allowing full access to a specific account:
 #  kms_policy =  <<POLICY

--- a/s3_bucket/versions.tf
+++ b/s3_bucket/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.2.0"
+    }
+  }
+}

--- a/s3_bucket/versions.tf
+++ b/s3_bucket/versions.tf
@@ -5,5 +5,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.2.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.1.0"
+    }
   }
 }


### PR DESCRIPTION
- left existing private_bucket in case already in use, but can likely migrate over any that are using it later if needed
- most importantly : Adding deny SSL policy by default (deny unencrypted connections non-https, non-TLS), this is optionable in case an older S3 site may use http
- If using variable custom_policy, we dynamically add in addition to denying SSL to the same policy
- feature for AWS S3 logging w/ dedicated logging bucket created.
- feature for 'guaranteed_uniqueness' using random 8 bytes appended to bucket name var.bucket_name
- README.md provided