### PR TITLE
DP-41798 : add permission notifier module

### DIFF
--- a/permission-alert/README.md
+++ b/permission-alert/README.md
@@ -1,0 +1,78 @@
+# IAM Role Admin Privilege Monitor
+
+This project provides an automated way to **monitor IAM roles for privilege escalation**. It leverages AWS EventBridge, Lambda, and SNS to detect when IAM role permissions change and sends an alert if administrative privileges are added.
+
+---
+
+## Overview
+
+- **Input:** One or more IAM role names to monitor.
+- **Event Trigger:** AWS EventBridge rule that listens for `IAM Role Policy` changes.
+- **Detection:** A Lambda function (written in TypeScript) inspects the target role’s:
+  - Inline policies
+  - Attached custom policies
+  - Attached managed policies
+- **Alerting:** If the role gains `AdministratorAccess` or wildcard permissions (`*` actions/resources), the Lambda publishes a message to the specified SNS topic.
+
+This helps prevent **unauthorized privilege escalation** in AWS accounts.
+
+---
+
+## Architecture
+
+1. **Terraform Module**
+   - Creates EventBridge rule for IAM role policy changes
+   - Provisions a Lambda function with detection logic
+   - Grants Lambda necessary IAM permissions
+   - Connects Lambda to SNS topic for alerts
+
+2. **Lambda Function (TypeScript)**
+   - Fetches IAM role policy details
+   - Detects admin-like privileges
+   - Publishes findings to SNS
+
+---
+
+## Project Structure
+
+.
+├── main.tf # Root module entrypoint
+├── iam.tf # IAM permissions for Lambda
+├── lambda.tf # Lambda packaging and deployment
+├── cw_events.tf # CloudWatch / EventBridge rules
+├── outputs.tf # Module outputs
+├── variables.tf # Input variables
+├── versions.tf # Provider versions
+└── lambda/
+
+---
+
+## Inputs
+
+| Variable        | Type           | Description                                                     |
+| --------------- | -------------- | --------------------------------------------------------------- |
+| `role_names`    | `list(string)` | List of IAM role names to monitor (e.g. `["role_A", "role_B"]`) |
+| `sns_topic_arn` | `string`       | ARN of an existing SNS topic to publish alerts                  |
+
+---
+
+## Outputs
+
+| Output        | Description                                          |
+| ------------- | ---------------------------------------------------- |
+| `lambda_name` | Name of the monitoring Lambda function               |
+| `rule_arn`    | ARN of the EventBridge rule that triggers the Lambda |
+
+---
+
+## Usage
+
+Example Terraform configuration:
+
+```hcl
+module "iam_role_alerts" {
+  source        = "<path_to_this_repository_and_version>"
+  sns_topic_arn = aws_sns_topic.role_policy_alerts.arn
+  role_names    = ["my-infra-apply-role", "my-infra-plan-role"]
+}
+```

--- a/permission-alert/cw_events.tf
+++ b/permission-alert/cw_events.tf
@@ -1,0 +1,37 @@
+# EventBridge rule to react to any IAM changes that could elevate privileges
+# While this detects changes to any role, the Lambda will filter to just the target role
+resource "aws_cloudwatch_event_rule" "iam_changes" {
+  name        = "role-admin-detector-iam-events"
+  description = "Trigger when IAM role/policy changes occur"
+
+  event_pattern = jsonencode({
+    "source" : ["aws.iam"],
+    "detail-type" : ["AWS API Call via CloudTrail"],
+    "detail" : {
+      "eventSource" : ["iam.amazonaws.com"],
+      "eventName" : [
+        # Attach/detach/inline policy changes for roles
+        "AttachRolePolicy",
+        "DetachRolePolicy",
+        "PutRolePolicy",
+        "DeleteRolePolicy",
+        # Managed policy lifecycle that could affect effective perms
+        "CreatePolicy",
+        "CreatePolicyVersion",
+        "SetDefaultPolicyVersion",
+        "DeletePolicyVersion",
+        "CreatePolicyVersion",
+        # Permissions boundary or trust changes (paranoid coverage)
+        "PutRolePermissionsBoundary",
+        "DeleteRolePermissionsBoundary",
+        "UpdateAssumeRolePolicy"
+      ]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "to_lambda" {
+  rule      = aws_cloudwatch_event_rule.iam_changes.name
+  target_id = "role-admin-detector"
+  arn       = aws_lambda_function.detector.arn
+}

--- a/permission-alert/iam.tf
+++ b/permission-alert/iam.tf
@@ -1,0 +1,62 @@
+data "aws_iam_policy_document" "detector_lambda_assume" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "detector_lambda" {
+  name               = "iam-admin-detector-role"
+  assume_role_policy = data.aws_iam_policy_document.detector_lambda_assume.json
+}
+
+# Permissions for:
+# - Reading IAM role policies (attached + inline)
+# - Publishing to SNS
+# - Writing CloudWatch Logs
+data "aws_iam_policy_document" "detector_permissions" {
+  statement {
+    sid    = "IamRead"
+    effect = "Allow"
+    actions = [
+      "iam:GetPolicy",
+      "iam:GetPolicyVersion",
+      "iam:GetRolePolicy",
+      "iam:ListRolePolicies",
+      "iam:ListAttachedRolePolicies"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid       = "AllowPublishToTopic"
+    effect    = "Allow"
+    actions   = ["sns:Publish"]
+    resources = [var.sns_topic_arn]
+  }
+
+  statement {
+    sid    = "Logs"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = ["arn:aws:logs:*:*:*"]
+  }
+}
+
+resource "aws_iam_policy" "detector_inline" {
+  name   = "iam-admin-detector-inline"
+  policy = data.aws_iam_policy_document.detector_permissions.json
+}
+
+resource "aws_iam_role_policy_attachment" "detector_inline_attach" {
+  role       = aws_iam_role.detector_lambda.name
+  policy_arn = aws_iam_policy.detector_inline.arn
+}

--- a/permission-alert/lambda.tf
+++ b/permission-alert/lambda.tf
@@ -1,0 +1,48 @@
+# Build the TypeScript Lambda locally using esbuild
+resource "null_resource" "build_lambda" {
+  triggers = {
+    src_hash      = filesha256("${path.module}/lambda/src/index.ts")
+    pkg_hash      = filesha256("${path.module}/lambda/package.json")
+    lock_hash     = fileexists("${path.module}/lambda/package-lock.json") ? filesha256("${path.module}/lambda/package-lock.json") : ""
+    tsconfig_hash = filesha256("${path.module}/lambda/tsconfig.json")
+  }
+
+  provisioner "local-exec" {
+    command = "cd ${path.module}/lambda && npm ci && npm run build"
+  }
+}
+
+data "archive_file" "detector_zip" {
+  type        = "zip"
+  source_file = "${path.module}/lambda/dist/index.js"
+  output_path = "${path.module}/lambda/detector.zip"
+
+  depends_on = [null_resource.build_lambda]
+}
+
+resource "aws_lambda_function" "detector" {
+  function_name = "role-admin-detector"
+  role          = aws_iam_role.detector_lambda.arn
+  handler       = "index.handler"
+  runtime       = "nodejs20.x"
+
+  filename         = data.archive_file.detector_zip.output_path
+  source_code_hash = data.archive_file.detector_zip.output_base64sha256
+
+  environment {
+    variables = {
+      SNS_TOPIC_ARN = var.sns_topic_arn
+      TARGET_ROLES  = join(",", var.role_names)
+    }
+  }
+
+  timeout = 30
+}
+
+resource "aws_lambda_permission" "allow_events" {
+  statement_id  = "AllowExecutionFromEventBridge"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.detector.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.iam_changes.arn
+}

--- a/permission-alert/lambda/package.json
+++ b/permission-alert/lambda/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "iam-admin-detector",
+  "version": "1.0.0",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/index.js"
+  },
+  "dependencies": {
+    "@aws-sdk/client-iam": "^3.609.0",
+    "@aws-sdk/client-sns": "^3.609.0"
+  },
+  "devDependencies": {
+    "esbuild": "^0.23.0",
+    "typescript": "^5.6.2",
+    "@types/node": "^22.5.4",
+    "@types/aws-lambda": "^8.10.137"
+  }
+}

--- a/permission-alert/lambda/src/index.ts
+++ b/permission-alert/lambda/src/index.ts
@@ -1,0 +1,185 @@
+import { IAMClient, GetPolicyCommand, GetPolicyVersionCommand, ListAttachedRolePoliciesCommand, ListRolePoliciesCommand, GetRolePolicyCommand } from "@aws-sdk/client-iam";
+import { SNSClient, PublishCommand } from "@aws-sdk/client-sns";
+
+const SNS_TOPIC_ARN = process.env.SNS_TOPIC_ARN || "";
+const ADMIN_ARN     = "arn:aws:iam::aws:policy/AdministratorAccess";
+
+function loadTargetRoles(): string[] {
+  const rawRoles = process.env.TARGET_ROLES?.trim();
+  const single   = process.env.TARGET_ROLE?.trim();
+  if (rawRoles) {
+    try {
+      const j = JSON.parse(rawRoles);
+      if (Array.isArray(j)) {
+        return j.map(x => String(x).trim()).filter(Boolean);
+      }
+    } catch {
+
+      return rawRoles.split(",").map(x => x.trim()).filter(Boolean);
+    }
+  }
+  return single ? [single] : [];
+}
+
+const TARGET_ROLES = Array.from(new Set(loadTargetRoles()));
+
+const iam = new IAMClient({});
+const sns = new SNSClient({});
+
+type PolicyDoc = Record<string, any> | null;
+
+function normalize<T>(v: T | T[] | undefined | null): T[] {
+  if (v == null) return [];
+  return Array.isArray(v) ? v : [v];
+}
+
+function tryParsePolicyDoc(raw: any): PolicyDoc {
+  if (!raw) return null;
+  if (typeof raw === "object") return raw as PolicyDoc;
+  if (typeof raw === "string") {
+    // Inline policies are sometimes likely url encoded
+    const variants = [
+      raw,
+      raw.replace(/\+/g, " "),
+      (() => { try { return decodeURIComponent(raw); } catch { return raw; } })(),
+      (() => { try { return decodeURIComponent(raw.replace(/\+/g, " ")); } catch { return raw; } })(),
+    ];
+    for (const s of variants) {
+      try { return JSON.parse(s); } catch { /* oof keep trying */ }
+    }
+  }
+  return null;
+}
+
+function hasAdminWildcards(doc: PolicyDoc): boolean {
+  if (!doc) return false;
+  let stmts: any = (doc as any).Statement ?? [];
+  if (!Array.isArray(stmts)) stmts = [stmts];
+
+  for (const s of stmts) {
+    if (String(s?.Effect ?? "").toLowerCase() !== "allow") continue;
+    const actions   = normalize<string>(s?.Action).map(String);
+    const resources = normalize<string>(s?.Resource).map(String);
+
+    const actionWild   = actions.some(a => a.includes("*"));
+    const resourceWild = resources.some(r => r === "*" || r.includes("*"));
+
+    if (actionWild && resourceWild) return true;
+  }
+  return false;
+}
+
+async function roleHasAdmin(roleName: string): Promise<{ isAdmin: boolean; reason: string }> {
+  // straight AdministratorAccess attachment
+  {
+    let marker: string | undefined = undefined;
+    do {
+      const out = await iam.send(new ListAttachedRolePoliciesCommand({ RoleName: roleName, Marker: marker }));
+      for (const ap of out.AttachedPolicies ?? []) {
+        if (ap.PolicyArn === ADMIN_ARN) {
+          return { isAdmin: true, reason: "AdministratorAccess managed policy attached" };
+        }
+      }
+      marker = out.Marker;
+    } while (marker);
+  }
+
+  // find them wildcards inside managed policies
+  {
+    let marker: string | undefined = undefined;
+    do {
+      const out = await iam.send(new ListAttachedRolePoliciesCommand({ RoleName: roleName, Marker: marker }));
+      for (const ap of out.AttachedPolicies ?? []) {
+        if (!ap.PolicyArn) continue;
+        const pol = await iam.send(new GetPolicyCommand({ PolicyArn: ap.PolicyArn }));
+        const verId = pol.Policy?.DefaultVersionId;
+        if (!verId) continue;
+
+        const ver = await iam.send(new GetPolicyVersionCommand({ PolicyArn: ap.Policy?.Arn!, VersionId: verId }));
+        const doc = tryParsePolicyDoc(ver.PolicyVersion?.Document as any);
+        if (hasAdminWildcards(doc)) {
+          return { isAdmin: true, reason: `Wildcard admin detected in managed policy ${ap.PolicyName}` };
+        }
+      }
+      marker = out.Marker;
+    } while (marker);
+  }
+
+  // find them Wildcards inside inline policies
+  {
+    let marker: string | undefined = undefined;
+    do {
+      const out = await iam.send(new ListRolePoliciesCommand({ RoleName: roleName, Marker: marker }));
+      for (const name of out.PolicyNames ?? []) {
+        const pol = await iam.send(new GetRolePolicyCommand({ RoleName: roleName, PolicyName: name }));
+        const doc = tryParsePolicyDoc(pol.PolicyDocument ?? "");
+        if (hasAdminWildcards(doc)) {
+          return { isAdmin: true, reason: `Wildcard admin detected in inline policy ${name}` };
+        }
+      }
+      marker = out.Marker;
+    } while (marker);
+  }
+
+  return { isAdmin: false, reason: "" };
+}
+
+async function publish(message: any): Promise<void> {
+  await sns.send(new PublishCommand({
+    TopicArn: SNS_TOPIC_ARN,
+    Subject: "ALERT: Role granted Administrator-like privileges",
+    Message: JSON.stringify(message),
+  }));
+}
+
+function extractEventRoleName(evt: any): string | undefined {
+  try {
+    const detail = evt?.detail ?? {};
+    const req    = detail?.requestParameters ?? {};
+    return req?.roleName;
+  } catch {
+    return undefined;
+  }
+}
+
+export const handler = async (event: any) => {
+  if (!SNS_TOPIC_ARN) {
+    return { ok: false, error: "SNS_TOPIC_ARN not set" };
+  }
+  if (TARGET_ROLES.length === 0) {
+    return { ok: true, skipped: true, reason: "no TARGET_ROLES configured" };
+  }
+
+  const monitored = TARGET_ROLES;
+  const roleInEvent = extractEventRoleName(event);
+
+  let rolesToCheck: string[] = [];
+  if (roleInEvent) {
+    if (!monitored.includes(roleInEvent)) {
+      return { ok: true, skipped: true, reason: `event not for a monitored role (${roleInEvent})` };
+    }
+    rolesToCheck = [roleInEvent];
+  } else {
+    rolesToCheck = monitored;
+  }
+
+  const findings: Array<{ role: string; alerted: boolean; reason?: string }> = [];
+  let alertedAny = false;
+
+  for (const rn of rolesToCheck) {
+    const { isAdmin, reason } = await roleHasAdmin(rn);
+    if (isAdmin) {
+      await publish({
+        role: rn,
+        reason,
+        note: "Detected AdministratorAccess or wildcard Allow (* on Action AND Resource).",
+      });
+      alertedAny = true;
+      findings.push({ role: rn, alerted: true, reason });
+    } else {
+      findings.push({ role: rn, alerted: false });
+    }
+  }
+
+  return { ok: true, alerted_any: alertedAny, findings, monitored_roles: monitored, event_role: roleInEvent };
+};

--- a/permission-alert/lambda/tsconfig.json
+++ b/permission-alert/lambda/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/permission-alert/main.tf
+++ b/permission-alert/main.tf
@@ -1,0 +1,3 @@
+locals {
+  admin_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}

--- a/permission-alert/outputs.tf
+++ b/permission-alert/outputs.tf
@@ -1,0 +1,39 @@
+output "lambda_function_name" {
+  description = "The name of the Lambda function monitoring IAM roles."
+  value       = aws_lambda_function.detector.function_name
+}
+
+output "lambda_function_arn" {
+  description = "The ARN of the Lambda function monitoring IAM roles."
+  value       = aws_lambda_function.detector.arn
+}
+
+output "lambda_execution_role_name" {
+  description = "The name of the IAM role assumed by the Lambda function."
+  value       = aws_iam_role.detector_lambda.name
+}
+
+output "lambda_execution_role_arn" {
+  description = "The ARN of the IAM role assumed by the Lambda function."
+  value       = aws_iam_role.detector_lambda.arn
+}
+
+output "eventbridge_rule_arn" {
+  description = "The ARN of the EventBridge rule for IAM changes."
+  value       = aws_cloudwatch_event_rule.iam_changes.arn
+}
+
+output "eventbridge_target_id" {
+  description = "The ID of the EventBridge target linking the rule to the Lambda."
+  value       = aws_cloudwatch_event_target.to_lambda.target_id
+}
+
+output "sns_topic_arn" {
+  description = "The SNS topic ARN used for alert notifications."
+  value       = var.sns_topic_arn
+}
+
+output "monitored_role_names" {
+  description = "The IAM Role names being monitored for admin privileges."
+  value       = var.role_names
+}

--- a/permission-alert/variables.tf
+++ b/permission-alert/variables.tf
@@ -1,0 +1,10 @@
+variable "role_names" {
+  description = "List of IAM role names to monitor for admin-like privileges"
+  type        = list(string)
+  default     = []
+}
+
+variable "sns_topic_arn" {
+  description = "Existing SNS topic ARN to publish alerts to."
+  type        = string
+}

--- a/permission-alert/versions.tf
+++ b/permission-alert/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.4.0"
+    }
+  }
+}

--- a/permission-alert/versions.tf
+++ b/permission-alert/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.87.0, < 6.0.0"
     }
     archive = {
       source  = "hashicorp/archive"
@@ -10,3 +10,4 @@ terraform {
     }
   }
 }
+


### PR DESCRIPTION
- Used to determine if github action/deployment role changes have added inline, custom, or managed administrator permissions
- pass a variable including the role names (single [] or list []), the sns topic (often linked to slack,teams, or emails)