### PR TITLE
DP-41784: Allow dependent projects to use aws provider version 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.x] - 2025-09-19
+  - [Cloudwatch Metric] module to allow hashicorp/aws version greater than 5
+
 ## [1.0.118] - 2025-09-12
 
 - [Terraform Boostreap] Export KMS key ARN for S3 bucket.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ These Terraform modules are used by other Terraform code.  Development happens i
 Contributing
 ------------
 
-When you update a module in this repository, please update [CHANGELOG.md](./CHANGELOG.MD) with a description of the change made to each module headed under a new version tag and the release date. For example, if the current version tag is `1.0.99` and you're planning to release changes to [asg](./asg/) and [ecscluster](./ecscluster) on January 1 2025, a possible CHANGELOG line might look like
+When you update a module in this repository, please update [CHANGELOG.md](./CHANGELOG.md) with a description of the change made to each module headed under a new version tag and the release date. For example, if the current version tag is `1.0.99` and you're planning to release changes to [asg](./asg/) and [ecscluster](./ecscluster) on January 1 2025, a possible CHANGELOG line might look like
 
 ```md
 ## [1.0.100] - 2025-01-01

--- a/cloudwatch-metrics/versions.tf
+++ b/cloudwatch-metrics/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.87.0"
+      version = ">= 5.87.0"
     }
   }
 }


### PR DESCRIPTION
## 🎫 Ticket

https://massgov.atlassian.net/browse/DP-41784

## 🛠 Changes

Allow dependent projects to use a higher version of aws


## ℹ️ Context for reviewers

To use differing input and output actions for https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrock_guardrail , we will eventually need to upgrade the Seamless Engagement infrastructure to use AWS version 6.13.0 or above.


Notes about the change are on https://github.com/hashicorp/terraform-provider-aws/releases/tag/v6.13.0
Usage is on https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrock_guardrail and can be compared to how it was set up on 5.87.0 at https://registry.terraform.io/providers/hashicorp/aws/5.87.0/docs/resources/bedrock_guardrail .
Upgrade notes can be found at https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-6-upgrade