### PR TITLE
DP-42171: Allow cloudwatch metrics to have newer terraform version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.x] - 2025-10-03
+  - [Cloudwatch Metric] module to allow terraform version greater than 1.9.2
+
 ## [1.x] - 2025-09-19
   - [Cloudwatch Metric] module to allow hashicorp/aws version greater than 5
 

--- a/cloudwatch-metrics/versions.tf
+++ b/cloudwatch-metrics/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.9.2"
+  required_version = ">= 1.9.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
## 🎫 Ticket

https://massgov.atlassian.net/browse/DP-42171

## 🛠 Changes

Allow cloudwatch metrics module to have a newer terraform version

## ℹ️ Context for reviewers

I was working on a terraform change and thought it might be a good point to upgrade to a newer terraform version, since I'll be testing some of the changes anyway. I noticed that this module didn't allow a newer version.