### PR TITLE
DP-42000: Updates to Ecs_Fargate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.0.121] - 2025-11-04
+- [Ecs Fargate] 
+  - Update AWS Version
+  - New: `var.ecs_create_auto_scale_arn` to create a new auto scaling role vs passing one in
+  - Update: `current.name` to `current.region` for deprecation
+  - Update: Allow `ec2_alb_arn` to be null, when skips creation of listener rule and target group attachment
+
+
 ## [1.0.120] - 2025-10-17
   - [Proto Instance] Adds `proto-instance` module for creating managed dev instances
 

--- a/cloudwatch-metrics/versions.tf
+++ b/cloudwatch-metrics/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.87.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/ecs_fargate/ecs.tf
+++ b/ecs_fargate/ecs.tf
@@ -187,7 +187,7 @@ resource "aws_ecs_service" "main" {
 
 // optional: scaling target for scaling policies
 resource "aws_appautoscaling_target" "main" {
-  count              = length(var.ecs_auto_scale_arn) == 0 ? 0 : 1
+  count              = length(var.ecs_auto_scale_arn) == 0 || var.ecs_create_auto_scale_arn == false ? 0 : 1
   max_capacity       = var.ecs_max_count
   min_capacity       = var.ecs_min_count
   resource_id        = "service/${data.aws_ecs_cluster.main.cluster_name}/${aws_ecs_service.main[count.index].name}"
@@ -199,7 +199,7 @@ resource "aws_appautoscaling_target" "main" {
 
 // optional: scale up when memory is over X %
 resource "aws_appautoscaling_policy" "memory" {
-  count = length(var.ecs_auto_scale_arn) == 0 ? 0 : var.ecs_auto_scale_memory == 0 ? 0 : 1
+  count = length(var.ecs_auto_scale_arn) == 0 || var.ecs_create_auto_scale_arn == false ? 0 : var.ecs_auto_scale_memory == 0 ? 0 : 1
 
   name               = "${data.aws_ecs_cluster.main.cluster_name}-${aws_ecs_service.main[0].name}-mem-autoScalingPolicy"
   policy_type        = "TargetTrackingScaling"
@@ -217,7 +217,7 @@ resource "aws_appautoscaling_policy" "memory" {
 
 // optional: scale up when cpu is over X %
 resource "aws_appautoscaling_policy" "cpu" {
-  count = length(var.ecs_auto_scale_arn) == 0 ? 0 : var.ecs_auto_scale_cpu == 0 ? 0 : 1
+  count =length(var.ecs_auto_scale_arn) == 0 || var.ecs_create_auto_scale_arn == false  ? 0 : var.ecs_auto_scale_cpu == 0 ? 0 : 1
 
   name               = "${data.aws_ecs_cluster.main.cluster_name}-${aws_ecs_service.main[0].name}-cpu-autoScalingPolicy"
   policy_type        = "TargetTrackingScaling"
@@ -236,7 +236,7 @@ resource "aws_appautoscaling_policy" "cpu" {
 
 // optional: spin service down on a schedule
 resource "aws_appautoscaling_scheduled_action" "schedule_down" {
-  count              = length(var.ecs_auto_scale_arn) == 0 ? 0 : var.ecs_auto_scale_schedule_down == "0" ? 0 : 1
+  count              = length(var.ecs_auto_scale_arn) == 0 || var.ecs_create_auto_scale_arn == false ? 0 : var.ecs_auto_scale_schedule_down == "0" ? 0 : 1
   name               = "${data.aws_ecs_cluster.main.cluster_name}-${aws_ecs_service.main[0].name}-schedule-down"
   resource_id        = aws_appautoscaling_target.main[count.index].id
   scalable_dimension = aws_appautoscaling_target.main[count.index].scalable_dimension
@@ -251,7 +251,7 @@ resource "aws_appautoscaling_scheduled_action" "schedule_down" {
 
 // optional: spin service up on a schedule
 resource "aws_appautoscaling_scheduled_action" "schedule_up" {
-  count              = length(var.ecs_auto_scale_arn) == 0 ? 0 : var.ecs_auto_scale_schedule_up == "0" ? 0 : 1
+  count              = length(var.ecs_auto_scale_arn) == 0 || var.ecs_create_auto_scale_arn == false ? 0 : var.ecs_auto_scale_schedule_up == "0" ? 0 : 1
   name               = "${data.aws_ecs_cluster.main.cluster_name}-${aws_ecs_service.main[0].name}-schedule-down"
   resource_id        = aws_appautoscaling_target.main[count.index].id
   scalable_dimension = aws_appautoscaling_target.main[count.index].scalable_dimension

--- a/ecs_fargate/ecs.tf
+++ b/ecs_fargate/ecs.tf
@@ -11,13 +11,13 @@ locals {
       environment : t.environment_vars
       secrets : [
         for s in t.secret_vars :
-        { name : s.name, valueFrom : "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/${s.valueFrom}" }
+        { name : s.name, valueFrom : "arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter/${s.valueFrom}" }
       ]
       logConfiguration : {
         logDriver : "awslogs",
         options : {
           awslogs-group : try(t.log_group_name, null) != null ? t.log_group_name : aws_cloudwatch_log_group.main[t.container_name].name
-          awslogs-region : data.aws_region.current.name,
+          awslogs-region : data.aws_region.current.region,
           awslogs-stream-prefix : "ecs"
         }
       }
@@ -321,7 +321,7 @@ module "teamsalerts" {
   source                      = "../teamsalerts"
   name                        = join("", [var.ecs_service_name, "Teams", "Alert"])
   human_name                  = "${var.ecs_cluster_name} ${var.ecs_service_name} Teams Alerts"
-  teams_webhook_url_param_arn = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/${var.teams_webhook_param_arn}"
+  teams_webhook_url_param_arn = "arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter/${var.teams_webhook_param_arn}"
   teams_webhook_url_param_key = var.teams_webhook_url_param_key
   topic_map = [
     {

--- a/ecs_fargate/iam.tf
+++ b/ecs_fargate/iam.tf
@@ -37,3 +37,58 @@ resource "aws_iam_role_policy" "ecs_events_run_task_with_any_role" {
   role   = aws_iam_role.ecs_schedule_role[0].name
   policy = data.aws_iam_policy_document.ecs_events_run_task_with_any_role[0].json
 }
+
+// Ff ecs_create_auto_scale_arn == true, create autoscaling role
+resource "aws_iam_role" "ecs_task_autoscale_role" {
+  count = var.ecs_create_auto_scale_arn ? 1 : 0
+  name  = "${var.ecs_cluster_name}-${var.ecs_task_name}-ecs-autoscale-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      },
+    ]
+  })
+}
+resource "aws_iam_policy" "ecs_task_autoscale_policy" {
+  count = var.ecs_create_auto_scale_arn ? 1 : 0
+  name  = "${var.ecs_cluster_name}-${var.ecs_task_name}-ecs-autoscale-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "application-autoscaling:DescribeScalableTargets",
+          "application-autoscaling:DescribeScalingPolicies",
+          "application-autoscaling:GetScalingPolicy",
+          "application-autoscaling:PutScalingPolicy",
+          "application-autoscaling:RegisterScalableTarget",
+          "application-autoscaling:DeregisterScalableTarget"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "cloudwatch:PutMetricAlarm",
+          "cloudwatch:DescribeAlarms",
+          "cloudwatch:DeleteAlarms",
+          "cloudwatch:DescribeAlarmHistory"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+resource "aws_iam_role_policy_attachment" "ecs_task_autoscale_policy_attachment" {
+  count      = var.ecs_create_auto_scale_arn ? 1 : 0
+  policy_arn = aws_iam_policy.ecs_task_autoscale_policy[0].arn
+  role       = aws_iam_role.ecs_task_autoscale_role[0].name
+}
+

--- a/ecs_fargate/networking.tf
+++ b/ecs_fargate/networking.tf
@@ -9,30 +9,9 @@ data "aws_lb_listener" "selected" {
   port              = coalesce(var.lb_listener_port, 443)
 }
 
-resource "aws_lb_target_group" "alb" {
-  for_each = length(coalesce(var.ecs_load_balancers, {})) != 0 ? var.ecs_load_balancers : {}
-
-  name                 = substr(join("-", [terraform.workspace, each.key, each.value["tls"] ? "HTTPS" : "HTTP"]), 0, 32)
-  port                 = lookup(each.value, "service_port", each.value["container_port"])
-  protocol             = each.value["tls"] ? "HTTPS" : "HTTP"
-  target_type          = "ip"
-  vpc_id               = var.vpc_id
-  deregistration_delay = "60"
-  health_check {
-    protocol            = each.value["tls"] ? "HTTPS" : "HTTP"
-    interval            = 10
-    path                = lookup(each.value, "health_check_path", "/")
-    timeout             = 5
-    unhealthy_threshold = 5
-    healthy_threshold   = 5
-    matcher             = lookup(each.value, "health_check_matcher", "200")
-  }
-  tags = {}
-}
-
 resource "aws_lb_listener_rule" "static" {
   depends_on = [aws_lb_target_group.alb]
-  for_each   = length(coalesce(var.ecs_load_balancers, {})) != 0 ? var.ecs_load_balancers : {}
+  for_each   = var.ec2_alb_arn == null ? {} : length(coalesce(var.ecs_load_balancers, {})) != 0 ? var.ecs_load_balancers : {}
 
   listener_arn = data.aws_lb_listener.selected[0].arn
   tags         = {}
@@ -75,3 +54,23 @@ resource "aws_lb_listener_rule" "static" {
   lifecycle { ignore_changes = [action] }
 }
 
+resource "aws_lb_target_group" "alb" {
+  for_each = length(coalesce(var.ecs_load_balancers, {})) != 0 ? var.ecs_load_balancers : {}
+
+  name                 = substr(join("-", [terraform.workspace, each.key, each.value["tls"] ? "HTTPS" : "HTTP"]), 0, 32)
+  port                 = lookup(each.value, "service_port", each.value["container_port"])
+  protocol             = each.value["tls"] ? "HTTPS" : "HTTP"
+  target_type          = "ip"
+  vpc_id               = var.vpc_id
+  deregistration_delay = "60"
+  health_check {
+    protocol            = each.value["tls"] ? "HTTPS" : "HTTP"
+    interval            = 10
+    path                = lookup(each.value, "health_check_path", "/")
+    timeout             = 5
+    unhealthy_threshold = 5
+    healthy_threshold   = 5
+    matcher             = lookup(each.value, "health_check_matcher", "200")
+  }
+  tags = {}
+}

--- a/ecs_fargate/variables.tf
+++ b/ecs_fargate/variables.tf
@@ -173,6 +173,11 @@ variable "ecs_auto_scale_arn" {
   type        = string
   default     = ""
 }
+variable "ecs_create_auto_scale_arn" {
+  description = "Create an Auto scale role"
+  type        = bool
+  default     = false
+}
 variable "ecs_security_group_ids" {
   description = "List of Security Group IDs"
   type        = list(string)

--- a/ecs_fargate/versions.tf
+++ b/ecs_fargate/versions.tf
@@ -6,7 +6,7 @@ terraform {
     aws = {
       source = "hashicorp/aws"
       # Needed for lambda module
-      version = ">= 4.8.0"
+      version = ">= 6.0.0"
     }
   }
 }


### PR DESCRIPTION
Seamless is wanting to add an API layer on ECS. 

  - Update AWS Version
  - New: `var.ecs_create_auto_scale_arn` to create a new auto scaling role vs passing one in
  - Update: `current.name` to `current.region` for deprecation
  - Update: Allow `ec2_alb_arn` to be null, when skips creation of listener rule and target group attachment

