### PR TITLE
DP-44322: Fast follow update to 1.0.122

### DIFF
--- a/asg/main.tf
+++ b/asg/main.tf
@@ -88,6 +88,13 @@ resource "aws_autoscaling_group" "default" {
     value               = var.name
   }
 
+  dynamic "instance_refresh" {
+    for_each = var.refresh_instances_on_update ? [1] : []
+    content {
+      strategy = "Rolling"
+    }
+  }
+
   dynamic "tag" {
     for_each = var.amazon_ecs_managed_tag ? [1] : []
 

--- a/asg/main.tf
+++ b/asg/main.tf
@@ -37,6 +37,12 @@ resource "aws_launch_template" "default" {
     arn = aws_iam_instance_profile.instance.arn
   }
 
+  metadata_options {
+    http_endpoint          = "enabled"
+    http_tokens            = "required"
+    instance_metadata_tags = "enabled"
+  }
+
   tag_specifications {
     resource_type = "instance"
 

--- a/asg/variables.tf
+++ b/asg/variables.tf
@@ -98,6 +98,12 @@ variable "instance_patch_group" {
   description = "Patch group to apply to EC2 instances."
 }
 
+variable "refresh_instances_on_update" {
+  type        = bool
+  default     = false
+  description = "When true, autoscaling group will perform an instance refresh when updates to its configuration are made"
+}
+
 variable "tags" {
   type        = map(string)
   description = "Additional tags to apply to all instances."

--- a/ecscluster/main.tf
+++ b/ecscluster/main.tf
@@ -87,7 +87,8 @@ module "asg" {
 
   block_devices = values(local.all_block_devices)
 
-  amazon_ecs_managed_tag = var.amazon_ecs_managed_tag
+  amazon_ecs_managed_tag      = var.amazon_ecs_managed_tag
+  refresh_instances_on_update = true
 
   tags = merge(
     var.tags,


### PR DESCRIPTION
## :hammer_and_pick: Changes

- Enables reading tags via EC2 instance metadata service (IMDS)
- Enabled instance refresh on ASGs that have been updated. This is helpful because sometimes for whatever reason the launch template version will change on the ASG but the change doesn't propagate.