### PR TITLE
DP-44708 : add custom policy option

### DIFF
--- a/gha-role/main.tf
+++ b/gha-role/main.tf
@@ -1,3 +1,7 @@
+locals {
+  trust_policy = var.custom_policy_json != "" ? var.custom_policy_json : data.aws_iam_policy_document.assume_policy.json
+}
+
 data "aws_iam_policy_document" "assume_policy" {
   statement {
     effect  = "Allow"
@@ -22,11 +26,16 @@ data "aws_iam_policy_document" "assume_policy" {
 }
 
 resource "aws_iam_role" "role" {
-  name                = var.role_name
-  path                = var.role_path
-  assume_role_policy  = data.aws_iam_policy_document.assume_policy.json
-  managed_policy_arns = var.policy_arns
+  name               = var.role_name
+  path               = var.role_path
+  assume_role_policy = local.trust_policy
   tags = {
     "Name" = var.role_name
   }
+}
+
+resource "aws_iam_role_policy_attachment" "policy_attachments" {
+  for_each   = toset(var.policy_arns)
+  role       = aws_iam_role.role.name
+  policy_arn = each.value
 }

--- a/gha-role/variables.tf
+++ b/gha-role/variables.tf
@@ -42,3 +42,10 @@ variable "oidc_subject_claims" {
   type    = list(string)
   default = ["*"]
 }
+
+# Custom IAM policy document in JSON format.
+variable "custom_policy_json" {
+  type        = string
+  description = "JSON IAM policy document to attach inline to the role"
+  default     = ""
+}

--- a/gha-role/variables.tf
+++ b/gha-role/variables.tf
@@ -43,9 +43,9 @@ variable "oidc_subject_claims" {
   default = ["*"]
 }
 
-# Custom IAM policy document in JSON format.
+# if templated (default) trust policy will not be used
 variable "custom_policy_json" {
   type        = string
-  description = "JSON IAM policy document to attach inline to the role"
+  description = "IAM policy document to attach inline to the role, use jsonencode() to convert Terraform language expressions to JSON"
   default     = ""
 }


### PR DESCRIPTION
- added new variable for custom json policy
-  if new variable is default ("") then it uses the standard data document policy as the assume role policy
-  if the new variable has value then it's used as the assume role policy