### PR TITLE
DP-44844 : added filter{} like aws provider wants so not to error out.

### DIFF
--- a/maintenance-calendar/s3.tf
+++ b/maintenance-calendar/s3.tf
@@ -47,9 +47,15 @@ resource "aws_s3_bucket_lifecycle_configuration" "maintenance_logs_lifecycle" {
   bucket = aws_s3_bucket.maintenance_logs.id
   rule {
     id = "log-expiration"
+
     expiration {
       days = 366
     }
+
+    filter {
+      prefix = var.s3_lifecycle_filter != null && var.s3_lifecycle_filter != "" ? var.s3_lifecycle_filter : ""
+    }
+
     status = "Enabled"
   }
 }

--- a/maintenance-calendar/variables.tf
+++ b/maintenance-calendar/variables.tf
@@ -42,7 +42,7 @@ variable "image_scan_ignore_arn" {
   description = <<EOF
     ARN of an SSM parameter containing CVEs that can safely be ignored.
     This parameter must be created manually if it doesn't already exist.
-    
+
     Parameter format: `[{"name":"CVE-2024-1", "packageName":"cowsay", "packageVersion":["1.2.3", "1.2.4"]},{"name"...}]`
   EOF
 }
@@ -53,7 +53,7 @@ variable "image_scan_snooze_arn" {
   description = <<EOF
     ARN of an SSM parameter containing ECS cluster names and a date to snooze alerts.
     This parameter must be created manually if it doesn't already exist.
-    
+
     Parameter format: `[{"cluster":"ecs-cluster-1", "snoozeUntil":"2024-10-24"},{"cluster"...}]`
   EOF
 }
@@ -79,4 +79,10 @@ variable "create_github_inactive_user_reminder" {
 variable "tags" {
   type    = map(string)
   default = {}
+}
+
+variable "s3_lifecycle_filter" {
+  type        = string
+  description = "A single filter prefix or tag to apply to the only S3 lifecycle rule"
+  default     = null
 }


### PR DESCRIPTION
- Newer versions of the AWS provider now take the absence of 'filter{}' as an error and no longer just a warning