### PR TITLE
DP-43822: Fix newline character parsing in manifest

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,8 +12,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
       - uses: hashicorp/setup-terraform@v3
       - run: terraform fmt -recursive -check || echo "Terraform fmt check failed. Run 'terraform fmt -recursive' to fix the formatting issues."
-      - name: Debug git status
-        run: git status && git diff
       - name: Check Terraform docs
         uses: terraform-docs/gh-actions@v1.4.1
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Debug git status
         run: git status && git diff
       - name: Check Terraform docs
-        uses: terraform-docs/gh-actions@v1.1.0
+        uses: terraform-docs/gh-actions@v1.4.1
         with:
           working-dir: ssm-session-monitor/,jump-box/,assume-role-alerts/,gha-environment/,gha-role/,terraform-bootstrap/,s3-backend-policy-documents/
           git-push: false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
       - uses: hashicorp/setup-terraform@v3
       - run: terraform fmt -recursive -check || echo "Terraform fmt check failed. Run 'terraform fmt -recursive' to fix the formatting issues."
+      - name: Debug git status
+        run: git status && git diff
       - name: Check Terraform docs
         uses: terraform-docs/gh-actions@v1.1.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.126] - 2026-03-24
+- [Tagging]
+  - Fix parsing of docs.manifest file ending in a newline character
+
 ## [1.0.124] - 2026-02-20
 - [Ecs Fargate]
   - Add support to set `readonlyRootFilesystem` bool

--- a/gha-role/README.md
+++ b/gha-role/README.md
@@ -25,16 +25,18 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_role.role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.policy_attachments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.assume_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_custom_policy_json"></a> [custom\_policy\_json](#input\_custom\_policy\_json) | IAM policy document to attach inline to the role, use jsonencode() to convert Terraform language expressions to JSON | `string` | `""` | no |
 | <a name="input_gh_org"></a> [gh\_org](#input\_gh\_org) | The name of the organization that owns the repository. | `string` | n/a | yes |
 | <a name="input_gh_repo"></a> [gh\_repo](#input\_gh\_repo) | The name of the repository. | `string` | n/a | yes |
 | <a name="input_oidc_provider_arn"></a> [oidc\_provider\_arn](#input\_oidc\_provider\_arn) | The ARN of the Github Actions OIDC provider. | `string` | n/a | yes |
-| <a name="input_oidc_subject_claims"></a> [oidc\_subject\_claims](#input\_oidc\_subject\_claims) | Additional filters to use for who can assume the role. You can filter by branch, tag, or environment. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
+| <a name="input_oidc_subject_claims"></a> [oidc\_subject\_claims](#input\_oidc\_subject\_claims) | Additional filters to use for who can assume the role. You can filter by branch, tag, or environment. | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
 | <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | IAM policies to attach to the role. | `list(string)` | n/a | yes |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The name of the role to create. | `string` | n/a | yes |
 | <a name="input_role_path"></a> [role\_path](#input\_role\_path) | The path for the role. | `string` | `"/soe/"` | no |

--- a/tagging/README.md
+++ b/tagging/README.md
@@ -33,12 +33,12 @@ provider "aws" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.87.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.37.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -49,16 +49,19 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_s3_object.category](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
+| [aws_s3_object.files](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
+| [aws_s3_bucket.docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [terraform_remote_state.tags](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
 ## Inputs
 
-| Name | Description                                                                       | Type | Default | Required |
-|------|-----------------------------------------------------------------------------------|------|---------|:--------:|
-| <a name="input_additional_tags"></a> [additional\_tags](#input\_additional\_tags) | Tags which will be merged into the managed tags provided by the module            | `map(string)` | `{}` |    no    |
-| <a name="input_org"></a> [org](#input\_org) | The name of the GitHub organization where calling code lives                      | `string` | `"massgov"` |    no    |
-| <a name="input_repo"></a> [repo](#input\_repo) | The name of the GitHub repository where calling code lives                        | `string` | n/a |   yes    |
-| <a name="input_manifest"></a> [manifest](#input\_manifest) | File path to docs.manifest file. See  [Manifest File](#manifest_file) for details | `string` | n/a |     no   |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_tags"></a> [additional\_tags](#input\_additional\_tags) | Tags which will be merged into the managed tags provided by the module | `map(string)` | `{}` | no |
+| <a name="input_manifest"></a> [manifest](#input\_manifest) | n/a | `string` | `null` | no |
+| <a name="input_org"></a> [org](#input\_org) | The name of the GitHub organization where calling code lives | `string` | `"massgov"` | no |
+| <a name="input_repo"></a> [repo](#input\_repo) | The name of the GitHub repository where calling code lives | `string` | n/a | yes |
 
 ## Outputs
 

--- a/tagging/variables.tf
+++ b/tagging/variables.tf
@@ -24,5 +24,7 @@ locals {
   manifest_path    = var.manifest
   root_level_count = local.manifest_path != null ? length(local.manifest_path) - length(replace(local.manifest_path, "/", "")) : ""
   relative_path    = local.manifest_path != null ? join("", [for i in range(local.root_level_count) : "../"]) : ""
-  file_list        = local.manifest_path != null ? split("\n", file(var.manifest)) : []
+  # Strips out empty lines, which can happen when the file ends in a newline character (posix standard).
+  file_list = local.manifest_path != null ? [for f in split("\n", file(var.manifest)) : f if trimspace(f) != ""] : []
 }
+


### PR DESCRIPTION
Ticket: https://massgov.atlassian.net/browse/DP-43822

Changelog: Fix parsing of docs.manifest file ending in a newline character and update terraform docs to fix PR checks


### Context

After updating the docs.manifest file from linux in https://github.com/massgov/virtual-assistant and merging, there was a failure to deploy.

```
Error: Error in function call

  on .terraform/modules/tags/tagging/s3.tf line 15, in resource "aws_s3_object" "files":
  15:   etag   = filemd5("${local.relative_path}${replace(replace(each.value, "../", ""), "./", "")}") # Use MD5 hash to detect changes
    ├────────────────
    │ while calling filemd5(path)
    │ each.value is ""
    │ local.relative_path is "../../../"

Call to function "filemd5" failed: read ../../..: is a directory.
Error: Terraform exited with code 1.
Error: Process completed with exit code 1.
```

This is because the newline character was added to the end of the file, causing the parsing logic to treat `""` as a value, causing the relative path to be a directory.

It's a posix standard for text files to end in a newline character per https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206 , so this should be supported.

It looks like the CHANGELOG.md file became out of sync with the releases. This PR doesn't fix it, but I'm happy to reconcile that if it's preferred.