### PR TITLE
DP-46943 : Make Lambda alarm parameters configurable

### DIFF
--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -124,13 +124,13 @@ resource "aws_cloudwatch_metric_alarm" "alarm" {
   count               = length(var.error_topics)
   alarm_name          = "${coalesce(var.human_name, var.name)} error"
   alarm_description   = "The Lambda function ${coalesce(var.human_name, var.name)} has errored"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
+  comparison_operator = var.alarm_comparison_operator
   evaluation_periods  = 1
   metric_name         = "Errors"
   namespace           = "AWS/Lambda"
-  period              = 60
-  threshold           = 1
-  statistic           = "Sum"
+  period              = var.alarm_period
+  threshold           = var.alarm_threshold
+  statistic           = var.alarm_statistic
   dimensions = {
     FunctionName = aws_lambda_function.default.function_name
   }

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -96,3 +96,26 @@ variable "error_topics" {
   default     = []
 }
 
+variable "alarm_comparison_operator" {
+  type        = string
+  description = "The comparison operator used for the Lambda error alarm"
+  default     = "GreaterThanOrEqualToThreshold"
+}
+
+variable "alarm_period" {
+  type        = number
+  description = "The period in seconds over which the specified statistic is applied"
+  default     = 60
+}
+
+variable "alarm_threshold" {
+  type        = number
+  description = "The value against which the specified statistic is compared"
+  default     = 1
+}
+
+variable "alarm_statistic" {
+  type        = string
+  description = "The statistic to apply to the alarm's associated metric"
+  default     = "Sum"
+}


### PR DESCRIPTION
- Changes to the module /lambda where the default value is the value of previous hard coded value.
- Any passed values to the variables to configure the lambda CW alarm will override the defaults (making values configurable).