### PR TITLE
Fix proto-instance Lambda unmount failure when /home is busy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.131] - 2026-05-15
+- [Proto Instance]
+  - Fix management Lambda failing to unmount /home when users are logged in
+
 ## [1.0.130] - 2026-05-13
 - [New Relic]
   - Add alert-workflow

--- a/proto-instance/lambda/index.ts
+++ b/proto-instance/lambda/index.ts
@@ -134,15 +134,19 @@ const unmountPartitionOnInstance = async (
       Comment: "Unmount user data partition",
       Parameters: {
         commands: [
-          "set -e",
           `mountpoint=$(lsblk -o MOUNTPOINT,PATH --json | jq -r '.blockdevices[] | select(.mountpoint == "/home").path')`,
-          'if [ -n "${mountpoint}" ]; then umount $mountpoint; else echo "Nothing to do - ${mountpoint} not mounted"; fi',
+          'if [ -z "${mountpoint}" ]; then echo "Nothing to do - not mounted"; exit 0; fi',
+          'wall "System maintenance: this instance will be rebuilt in 60 seconds. Save your work and disconnect." 2>/dev/null || true',
+          'sleep 60',
+          'fuser -km /home 2>/dev/null || true',
+          'sleep 2',
+          'umount $mountpoint || umount -l $mountpoint',
         ],
       },
     })
   );
   await waitUntilCommandExecuted(
-    { client: ssm, maxWaitTime: 90 },
+    { client: ssm, maxWaitTime: 120 },
     {
       CommandId: sendCommandResult.Command?.CommandId,
       InstanceId: instanceId,


### PR DESCRIPTION
The management Lambda's unmount step fails with "target is busy" when users have active sessions, preventing instance rebuilds indefinitely. Add a 60-second wall warning, kill processes on /home with fuser, and fall back to lazy unmount. Bump SSM command timeout from 90s to 120s to accommodate the grace period.