### PR TITLE
DP-47344: Fix SSM permissions for ECS scan AlertOnError step

### DIFF
--- a/maintenance-calendar/modules/ecs_scans/main.tf
+++ b/maintenance-calendar/modules/ecs_scans/main.tf
@@ -97,7 +97,9 @@ data "aws_iam_policy_document" "ecs_scans" {
       "ssm:StartAutomationExecution"
     ]
     resources = [
-      "arn:aws:ssm:${var.region}:${var.account_id}:automation-definition/${aws_ssm_document.ssr_scan_ecr_image.name}:$LATEST"
+      "arn:aws:ssm:${var.region}:${var.account_id}:automation-definition/${aws_ssm_document.ssr_scan_ecr_image.name}:$LATEST",
+      "arn:aws:ssm:${var.region}::automation-definition/AWS-PublishSNSNotification:$DEFAULT",
+      "arn:aws:ssm:${var.region}:${var.account_id}:automation-execution/*"
     ]
   }
   statement {


### PR DESCRIPTION
## Ticket
https://massgov.atlassian.net/browse/DP-47344

## Summary
- The `SSR-ECS-Scans-Role` only had `ssm:StartAutomationExecution` scoped to the `SSR-ScanECRImage` document
- The `AlertOnError` step calls `AWS-PublishSNSNotification` (a different automation), so the error notification silently fails with `AccessDeniedException`
- Adds the `AWS-PublishSNSNotification` document and `automation-execution/*` to the allowed resources

## Test plan
- [ ] Apply Terraform and trigger a scan error — confirm the SNS alert is sent successfully