### PR TITLE
DP-47768 : Upgrade to Node.js 22 across all modules using less than 20

### DIFF
--- a/archived/golden-ami-backups/lambda/package-lock.json
+++ b/archived/golden-ami-backups/lambda/package-lock.json
@@ -17,11 +17,11 @@
         "@aws-sdk/client-ec2": "^3.461.0",
         "@aws-sdk/client-sns": "^3.461.0",
         "@aws-sdk/client-ssm": "^3.461.0",
-        "@tsconfig/node18": "^18.2.2",
+        "@tsconfig/node22": "^22.0.0",
         "@types/archiver": "^5.3.2",
         "@types/assert": "^1.5.8",
         "@types/aws-lambda": "^8.10.126",
-        "@types/node": "^20.9.1",
+        "@types/node": "^22.0.0",
         "archiver": "^5.3.1",
         "esbuild": "^0.17.14",
         "prettier": "^3.1.0",
@@ -1748,10 +1748,10 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
-    "node_modules/@tsconfig/node18": {
-      "version": "18.2.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.2.tgz",
-      "integrity": "sha512-d6McJeGsuoRlwWZmVIeE8CUA27lu6jLjvv1JzqmpsytOYYbVi1tHZEnwCNVOXnj4pyLvneZlFlpXUK+X9wBWyw==",
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.5.tgz",
+      "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
       "dev": true
     },
     "node_modules/@types/archiver": {
@@ -1776,12 +1776,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.1.tgz",
-      "integrity": "sha512-HhmzZh5LSJNS5O8jQKpJ/3ZcrrlG6L70hpGqMIAoM9YVD0YBRNWYsfwcXq8VnSjlNpCpgLzMXdiPo+dxcvSmiA==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/readdir-glob": {
@@ -2961,9 +2961,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "node_modules/util": {

--- a/archived/golden-ami-backups/lambda/package.json
+++ b/archived/golden-ami-backups/lambda/package.json
@@ -15,11 +15,11 @@
     "@aws-sdk/client-ec2": "^3.461.0",
     "@aws-sdk/client-sns": "^3.461.0",
     "@aws-sdk/client-ssm": "^3.461.0",
-    "@tsconfig/node18": "^18.2.2",
+    "@tsconfig/node22": "^22.0.0",
     "@types/archiver": "^5.3.2",
     "@types/assert": "^1.5.8",
     "@types/aws-lambda": "^8.10.126",
-    "@types/node": "^20.9.1",
+    "@types/node": "^22.0.0",
     "archiver": "^5.3.1",
     "esbuild": "^0.17.14",
     "prettier": "^3.1.0",
@@ -27,7 +27,7 @@
     "typescript": "^5.2.2"
   },
   "volta": {
-    "node": "18.18.2"
+    "node": "22.11.0"
   },
   "dependencies": {
     "assert": "^2.1.0",

--- a/archived/golden-ami-backups/lambda/tsconfig.json
+++ b/archived/golden-ami-backups/lambda/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
     "experimentalDecorators": true,
     "resolveJsonModule": true,

--- a/archived/golden-ami-backups/main.tf
+++ b/archived/golden-ami-backups/main.tf
@@ -122,7 +122,7 @@ module "golden_ami_backups" {
   name       = "${var.name_prefix}-backup-lambda"
   human_name = var.human_name
   handler    = "index.handler"
-  runtime    = "nodejs18.x"
+  runtime    = "nodejs22.x"
   iam_policy_arns = [
     aws_iam_policy.publish_errors.arn,
     aws_iam_policy.read_parameter.arn,

--- a/archived/slackalerts/bin/build.ts
+++ b/archived/slackalerts/bin/build.ts
@@ -14,7 +14,7 @@ const run = async (): Promise<void> => {
     entryPoints: [path.join(__dirname, "..", "src", "index.ts")],
     bundle: true,
     platform: "node",
-    target: "node16",
+    target: "node22",
     outfile: path.join(tmp, "index.js")
   });
   const archivePath = path.join(__dirname, "..", "dist", "slackalerts.zip");

--- a/archived/slackalerts/main.tf
+++ b/archived/slackalerts/main.tf
@@ -7,7 +7,7 @@ resource "aws_lambda_function" "sns_to_slack" {
   function_name    = var.name
   handler          = "index.handler"
   role             = aws_iam_role.lambda.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs22.x"
   environment {
     variables = {
       SLACK_TOKEN     = var.SLACK_TOKEN
@@ -74,4 +74,3 @@ resource "aws_iam_role_policy" "lambda" {
   policy = data.aws_iam_policy_document.lambda_policy.json
   role   = aws_iam_role.lambda.id
 }
-

--- a/archived/slackalerts/package-lock.json
+++ b/archived/slackalerts/package-lock.json
@@ -13,12 +13,12 @@
         "assert": "^2.1.0"
       },
       "devDependencies": {
-        "@tsconfig/node16": "^16.1.1",
+        "@tsconfig/node22": "^22.0.0",
         "@types/archiver": "^5.3.2",
         "@types/assert": "^1.5.8",
         "@types/aws-lambda": "^8.10.114",
         "@types/jest": "^29.5.7",
-        "@types/node": "^20.8.10",
+        "@types/node": "^22.0.0",
         "archiver": "^5.3.1",
         "esbuild": "^0.17.14",
         "jest": "^29.7.0",
@@ -1581,10 +1581,10 @@
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true
     },
-    "node_modules/@tsconfig/node16": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.1.tgz",
-      "integrity": "sha512-+pio93ejHN4nINX4pXqfnR/fPLRtJBaT4ORaa5RH0Oc1zoYmo2B2koG+M328CQhHKn1Wj6FcOxCDFXAot9NhvA==",
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.5.tgz",
+      "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
       "dev": true
     },
     "node_modules/@types/archiver": {
@@ -1701,11 +1701,11 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.8.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
-      "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/p-queue": {
@@ -5115,9 +5115,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
@@ -6482,10 +6482,10 @@
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true
     },
-    "@tsconfig/node16": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.1.tgz",
-      "integrity": "sha512-+pio93ejHN4nINX4pXqfnR/fPLRtJBaT4ORaa5RH0Oc1zoYmo2B2koG+M328CQhHKn1Wj6FcOxCDFXAot9NhvA==",
+    "@tsconfig/node22": {
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.5.tgz",
+      "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
       "dev": true
     },
     "@types/archiver": {
@@ -6602,11 +6602,11 @@
       }
     },
     "@types/node": {
-      "version": "20.8.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
-      "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "requires": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "@types/p-queue": {
@@ -9109,9 +9109,9 @@
       "dev": true
     },
     "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "update-browserslist-db": {
       "version": "1.0.13",

--- a/archived/slackalerts/package.json
+++ b/archived/slackalerts/package.json
@@ -15,12 +15,12 @@
     "assert": "^2.1.0"
   },
   "devDependencies": {
-    "@tsconfig/node16": "^16.1.1",
+    "@tsconfig/node22": "^22.0.0",
     "@types/archiver": "^5.3.2",
     "@types/assert": "^1.5.8",
     "@types/aws-lambda": "^8.10.114",
     "@types/jest": "^29.5.7",
-    "@types/node": "^20.8.10",
+    "@types/node": "^22.0.0",
     "archiver": "^5.3.1",
     "esbuild": "^0.17.14",
     "jest": "^29.7.0",
@@ -29,6 +29,6 @@
     "typescript": "^5.2.2"
   },
   "volta": {
-    "node": "16.19.1"
+    "node": "22.11.0"
   }
 }

--- a/archived/slackalerts/tsconfig.json
+++ b/archived/slackalerts/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
     "experimentalDecorators": true,
     "resolveJsonModule": true,

--- a/entrypoint-monitoring/lambda/package-lock.json
+++ b/entrypoint-monitoring/lambda/package-lock.json
@@ -18,7 +18,7 @@
         "@aws-sdk/client-ssm": "^3.186.0"
       },
       "devDependencies": {
-        "@types/node": "^18.8.3",
+        "@types/node": "^22.0.0",
         "esbuild": "^0.15.11",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.5"
@@ -5320,10 +5320,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.8.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.3.tgz",
-      "integrity": "sha512-0os9vz6BpGwxGe9LOhgP/ncvYN5Tx1fNcd2TM3rD/aCGBkysb+ZWpXEocG24h6ZzOi13+VB8HndAQFezsSOw1w==",
-      "dev": true
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.8.0",
@@ -5821,6 +5824,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -10186,10 +10195,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.8.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.3.tgz",
-      "integrity": "sha512-0os9vz6BpGwxGe9LOhgP/ncvYN5Tx1fNcd2TM3rD/aCGBkysb+ZWpXEocG24h6ZzOi13+VB8HndAQFezsSOw1w==",
-      "dev": true
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "acorn": {
       "version": "8.8.0",
@@ -10445,6 +10457,12 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "uuid": {

--- a/entrypoint-monitoring/lambda/package.json
+++ b/entrypoint-monitoring/lambda/package.json
@@ -2,7 +2,7 @@
   "name": "massgov-aws-entrypoint-monitor",
   "version": "1.0.0",
   "devDependencies": {
-    "@types/node": "^18.8.3",
+    "@types/node": "^22.0.0",
     "esbuild": "^0.15.11",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5"
@@ -21,6 +21,6 @@
     "build": "node scripts/build.js"
   },
   "volta": {
-    "node": "20.13.0"
+    "node": "22.11.0"
   }
 }

--- a/entrypoint-monitoring/main.tf
+++ b/entrypoint-monitoring/main.tf
@@ -55,7 +55,7 @@ data "aws_iam_policy_document" "monitor_inline_policy" {
 module "monitor_lambda" {
   source  = "github.com/massgov/mds-terraform-common//lambda?ref=1.0.91"
   package = "${path.module}/package/lambda.zip"
-  runtime = "nodejs20.x"
+  runtime = "nodejs22.x"
   handler = "lambda.default"
   environment = {
     variables = merge({

--- a/maintenance-calendar/modules/ecs_scans/lambda.tf
+++ b/maintenance-calendar/modules/ecs_scans/lambda.tf
@@ -8,7 +8,7 @@ module "ecs_cluster_image_scan" {
   name       = local.lambda_name
   human_name = "SSR ECS Cluster Image Scan"
   handler    = "index.handler"
-  runtime    = "nodejs20.x"
+  runtime    = "nodejs22.x"
   iam_policy_arns = [
     var.publish_alerts_policy,
     aws_iam_policy.maintenance_ecs_scan_lambda.arn,

--- a/maintenance-calendar/modules/ecs_scans/lambda/package-lock.json
+++ b/maintenance-calendar/modules/ecs_scans/lambda/package-lock.json
@@ -18,11 +18,11 @@
         "@aws-sdk/client-ecs": "^3.461.0",
         "@aws-sdk/client-sns": "^3.461.0",
         "@aws-sdk/client-ssm": "^3.461.0",
-        "@tsconfig/node20": "^20.1.5",
+        "@tsconfig/node22": "^22.0.0",
         "@types/archiver": "^5.3.2",
         "@types/assert": "^1.5.8",
         "@types/aws-lambda": "^8.10.126",
-        "@types/node": "^20.9.1",
+        "@types/node": "^22.0.0",
         "archiver": "^5.3.1",
         "esbuild": "^0.17.14",
         "prettier": "^3.3.3",
@@ -1843,12 +1843,11 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.5",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.5.tgz",
-      "integrity": "sha512-Vm8e3WxDTqMGPU4GATF9keQAIy1Drd7bPwlgzKJnZtoOsTm1tduUTbDjg0W5qERvGuxPI2h9RbMufH0YdfBylA==",
-      "dev": true,
-      "license": "MIT"
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.5.tgz",
+      "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
+      "dev": true
     },
     "node_modules/@types/archiver": {
       "version": "5.3.4",
@@ -1872,12 +1871,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.13.tgz",
-      "integrity": "sha512-5G4zQwdiQBSWYTDAH1ctw2eidqdhMJaNsiIDKHFr55ihz5Trl2qqR8fdrT732yPBho5gkNxXm67OxWFBqX9aPg==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/readdir-glob": {
@@ -3053,9 +3052,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "node_modules/util": {

--- a/maintenance-calendar/modules/ecs_scans/lambda/package.json
+++ b/maintenance-calendar/modules/ecs_scans/lambda/package.json
@@ -16,11 +16,11 @@
     "@aws-sdk/client-ecs": "^3.461.0",
     "@aws-sdk/client-sns": "^3.461.0",
     "@aws-sdk/client-ssm": "^3.461.0",
-    "@tsconfig/node20": "^20.1.5",
+    "@tsconfig/node22": "^22.0.0",
     "@types/archiver": "^5.3.2",
     "@types/assert": "^1.5.8",
     "@types/aws-lambda": "^8.10.126",
-    "@types/node": "^20.9.1",
+    "@types/node": "^22.0.0",
     "archiver": "^5.3.1",
     "esbuild": "^0.17.14",
     "prettier": "^3.3.3",
@@ -28,7 +28,7 @@
     "typescript": "^5.4.5"
   },
   "volta": {
-    "node": "20.13.1"
+    "node": "22.11.0"
   },
   "dependencies": {
     "@js-joda/timezone": "^2.3.0",

--- a/maintenance-calendar/modules/ecs_scans/lambda/tsconfig.json
+++ b/maintenance-calendar/modules/ecs_scans/lambda/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
     "experimentalDecorators": true,
     "resolveJsonModule": true,

--- a/teamsalerts/lambda/package-lock.json
+++ b/teamsalerts/lambda/package-lock.json
@@ -14,10 +14,10 @@
       },
       "devDependencies": {
         "@aws-sdk/client-ssm": "^3.629.0",
-        "@tsconfig/node20": "^20.1.4",
+        "@tsconfig/node22": "^22.0.0",
         "@types/archiver": "^5.3.1",
         "@types/aws-lambda": "^8.10.110",
-        "@types/node": "^18.13.0",
+        "@types/node": "^22.0.0",
         "archiver": "^5.3.1",
         "esbuild": "^0.17.8",
         "prettier": "^2.8.4",
@@ -1662,10 +1662,10 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.4.tgz",
-      "integrity": "sha512-sqgsT69YFeLWf5NtJ4Xq/xAF8p4ZQHlmGW74Nu2tD4+g5fAsposc4ZfaaPixVu4y01BEiDCWLRDCvDM5JOsRxg==",
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.5.tgz",
+      "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
       "dev": true
     },
     "node_modules/@types/archiver": {
@@ -1700,10 +1700,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
-      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
-      "dev": true
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.8.2",
@@ -2634,6 +2637,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
     },
     "node_modules/util": {
       "version": "0.12.5",
@@ -3944,10 +3953,10 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
-    "@tsconfig/node20": {
-      "version": "20.1.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.4.tgz",
-      "integrity": "sha512-sqgsT69YFeLWf5NtJ4Xq/xAF8p4ZQHlmGW74Nu2tD4+g5fAsposc4ZfaaPixVu4y01BEiDCWLRDCvDM5JOsRxg==",
+    "@tsconfig/node22": {
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.5.tgz",
+      "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
       "dev": true
     },
     "@types/archiver": {
@@ -3982,10 +3991,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
-      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
-      "dev": true
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "acorn": {
       "version": "8.8.2",
@@ -4666,6 +4678,12 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "util": {

--- a/teamsalerts/lambda/package.json
+++ b/teamsalerts/lambda/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "devDependencies": {
     "@aws-sdk/client-ssm": "^3.629.0",
-    "@tsconfig/node20": "^20.1.4",
+    "@tsconfig/node22": "^22.0.0",
     "@types/archiver": "^5.3.1",
     "@types/aws-lambda": "^8.10.110",
-    "@types/node": "^18.13.0",
+    "@types/node": "^22.0.0",
     "archiver": "^5.3.1",
     "esbuild": "^0.17.8",
     "prettier": "^2.8.4",
@@ -23,6 +23,6 @@
     "prettier": "npx prettier --write '**/*.{js,jsx,ts,tsx,json}'"
   },
   "volta": {
-    "node": "20.13.0"
+    "node": "22.11.0"
   }
 }

--- a/teamsalerts/lambda/tsconfig.json
+++ b/teamsalerts/lambda/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
     "experimentalDecorators": true,
     "resolveJsonModule": true,

--- a/teamsalerts/main.tf
+++ b/teamsalerts/main.tf
@@ -43,7 +43,7 @@ resource "aws_iam_policy" "read_parameter_store" {
 module "sns_to_teams" {
   source  = "github.com/massgov/mds-terraform-common//lambda?ref=1.0.91"
   package = "${path.module}/lambda/dist/archive.zip"
-  runtime = "nodejs20.x"
+  runtime = "nodejs22.x"
   handler = "lambda.handler"
   environment = {
     variables = {

--- a/webhook-converters/github-to-teams/lambda/package-lock.json
+++ b/webhook-converters/github-to-teams/lambda/package-lock.json
@@ -14,9 +14,9 @@
         "zod": "^3.20.6"
       },
       "devDependencies": {
-        "@tsconfig/node20": "^20.1.4",
+        "@tsconfig/node22": "^22.0.0",
         "@types/aws-lambda": "^8.10.110",
-        "@types/node": "^18.8.3",
+        "@types/node": "^22.0.0",
         "dotenv": "^16.0.3",
         "esbuild": "^0.15.11",
         "ts-node": "^10.9.1",
@@ -1259,10 +1259,10 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.4.tgz",
-      "integrity": "sha512-sqgsT69YFeLWf5NtJ4Xq/xAF8p4ZQHlmGW74Nu2tD4+g5fAsposc4ZfaaPixVu4y01BEiDCWLRDCvDM5JOsRxg==",
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.5.tgz",
+      "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
       "dev": true
     },
     "node_modules/@types/aws-lambda": {
@@ -1272,10 +1272,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
-      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
-      "dev": true
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.8.2",
@@ -1858,6 +1861,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -2933,10 +2942,10 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
-    "@tsconfig/node20": {
-      "version": "20.1.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.4.tgz",
-      "integrity": "sha512-sqgsT69YFeLWf5NtJ4Xq/xAF8p4ZQHlmGW74Nu2tD4+g5fAsposc4ZfaaPixVu4y01BEiDCWLRDCvDM5JOsRxg==",
+    "@tsconfig/node22": {
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.5.tgz",
+      "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
       "dev": true
     },
     "@types/aws-lambda": {
@@ -2946,10 +2955,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
-      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
-      "dev": true
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "acorn": {
       "version": "8.8.2",
@@ -3264,6 +3276,12 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "uuid": {

--- a/webhook-converters/github-to-teams/lambda/package.json
+++ b/webhook-converters/github-to-teams/lambda/package.json
@@ -2,9 +2,9 @@
   "name": "massgov-aws-entrypoint-monitor",
   "version": "1.0.0",
   "devDependencies": {
-    "@tsconfig/node20": "^20.1.4",
+    "@tsconfig/node22": "^22.0.0",
     "@types/aws-lambda": "^8.10.110",
-    "@types/node": "^18.8.3",
+    "@types/node": "^22.0.0",
     "dotenv": "^16.0.3",
     "esbuild": "^0.15.11",
     "ts-node": "^10.9.1",
@@ -21,6 +21,6 @@
     "dev": "node scripts/build-local.js && node -r dotenv/config dist/local.js"
   },
   "volta": {
-    "node": "20.13.0"
+    "node": "22.11.0"
   }
 }

--- a/webhook-converters/github-to-teams/lambda/tsconfig.json
+++ b/webhook-converters/github-to-teams/lambda/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
     "rootDir": "./",
   }

--- a/webhook-converters/github-to-teams/main.tf
+++ b/webhook-converters/github-to-teams/main.tf
@@ -27,7 +27,7 @@ resource "random_password" "path_token" {
 module "lambda" {
   source  = "github.com/massgov/mds-terraform-common//lambda?ref=1.0.91"
   package = "${path.module}/package/lambda.zip"
-  runtime = "nodejs20.x"
+  runtime = "nodejs22.x"
   handler = "lambda.default"
   environment = {
     variables = merge({


### PR DESCRIPTION
Updated all Lambda functions and modules to now use Node.js 22.x runtime. (next acceptable level up that is still supported.)  Will tag with latest release once merged.

tf modules upgraded: 
entrypoint-monitoring
maintenance-calendar/modules/ecs_scans
teamsalerts
webhook-converters/github-to-teams
archived/golden-ami-backups
archived/slackalerts