### PR TITLE
DP-48309 : Add bool for additional subnet group creation to 'rdsinstance'

### DIFF
--- a/rdsinstance/main.tf
+++ b/rdsinstance/main.tf
@@ -8,7 +8,7 @@ resource "aws_db_subnet_group" "default" {
 
 resource "aws_db_subnet_group" "subnet_group" {
   count      = var.create_subnet_group ? 1 : 0
-  name       = "${var.name}-subnet-${count.index}"
+  name       = "${var.name}-subnet"
   subnet_ids = var.additional_subnets
 }
 

--- a/rdsinstance/main.tf
+++ b/rdsinstance/main.tf
@@ -9,7 +9,7 @@ resource "aws_db_subnet_group" "default" {
 resource "aws_db_subnet_group" "subnet_group" {
   count      = var.create_subnet_group ? 1 : 0
   name       = "${var.name}-subnet-${count.index}"
-  subnet_ids = var.subnets
+  subnet_ids = var.additional_subnets
 }
 
 // db instance

--- a/rdsinstance/main.tf
+++ b/rdsinstance/main.tf
@@ -8,7 +8,7 @@ resource "aws_db_subnet_group" "default" {
 
 resource "aws_db_subnet_group" "subnet_group" {
   count      = var.create_subnet_group ? 1 : 0
-  name       = "${var.name}-subnet"
+  name       = "${var.name}-subnet-${count.index}"
   subnet_ids = var.additional_subnets
 }
 
@@ -248,6 +248,7 @@ resource "aws_rds_cluster" "default" {
     },
   )
 }
+
 resource "aws_rds_cluster_instance" "cluster_instances" {
   count                                 = var.rds_instance_cluster == "cluster" ? var.rds_instance_count : 0
   cluster_identifier                    = aws_rds_cluster.default[0].id

--- a/rdsinstance/main.tf
+++ b/rdsinstance/main.tf
@@ -6,6 +6,11 @@ resource "aws_db_subnet_group" "default" {
   subnet_ids = var.subnets
 }
 
+resource "aws_db_subnet_group" "subnet_group" {
+  count      = var.create_subnet_group ? 1 : 0
+  name       = "${var.name}-subnet-${count.index}"
+  subnet_ids = var.subnets
+}
 
 // db instance
 resource "aws_db_instance" "default" {
@@ -26,7 +31,7 @@ resource "aws_db_instance" "default" {
   maintenance_window                    = "wed:04:00-wed:05:00"
   storage_encrypted                     = var.storage_encrypted
   parameter_group_name                  = var.parameter_group_name
-  db_subnet_group_name                  = aws_db_subnet_group.default.name
+  db_subnet_group_name                  = var.create_subnet_group ? aws_db_subnet_group.subnet_group[0].name : aws_db_subnet_group.default.name
   performance_insights_enabled          = var.performance_insights_enabled
   performance_insights_retention_period = var.performance_insights_retention_period
   monitoring_interval                   = var.monitoring_interval
@@ -231,7 +236,7 @@ resource "aws_rds_cluster" "default" {
   storage_encrypted                   = var.storage_encrypted
 
   preferred_backup_window = "05:10-06:00" # 12:10AM-1:00AM EST
-  db_subnet_group_name    = aws_db_subnet_group.default.name
+  db_subnet_group_name    = var.create_subnet_group ? aws_db_subnet_group.subnet_group[0].name : aws_db_subnet_group.default.name
   vpc_security_group_ids = flatten([
     var.security_groups,
     aws_security_group.db.id,
@@ -252,7 +257,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   instance_class                        = var.instance_class
   copy_tags_to_snapshot                 = true
   db_parameter_group_name               = var.parameter_group_name
-  db_subnet_group_name                  = aws_db_subnet_group.default.name
+  db_subnet_group_name                  = var.create_subnet_group ? aws_db_subnet_group.subnet_group[0].name : aws_db_subnet_group.default.name
   performance_insights_enabled          = var.performance_insights_enabled
   performance_insights_retention_period = var.performance_insights_retention_period
   monitoring_interval                   = var.monitoring_interval

--- a/rdsinstance/outputs.tf
+++ b/rdsinstance/outputs.tf
@@ -3,6 +3,11 @@ output "username" {
   value = try(aws_db_instance.default[0].username, null)
 }
 
+// DB Subnet Group Name
+output "db_subnet_group_name" {
+  value = try(aws_db_subnet_group.subnet_group[0].name, aws_db_subnet_group.default.name)
+}
+
 // Root password for the database.
 output "password" {
   value = try(aws_db_instance.default[0].password, null)

--- a/rdsinstance/variables.tf
+++ b/rdsinstance/variables.tf
@@ -58,6 +58,12 @@ variable "instance_class" {
   default     = "db.t2.micro"
 }
 
+variable "create_subnet_group" {
+  type        = bool
+  description = "Whether to create an additional DB subnet group."
+  default     = false
+}
+
 variable "allocated_storage" {
   type        = string
   description = "The allocated storage in GB"

--- a/rdsinstance/variables.tf
+++ b/rdsinstance/variables.tf
@@ -13,6 +13,12 @@ variable "subnets" {
   default     = []
 }
 
+variable "additional_subnets" {
+  type        = list(string)
+  description = "Additional subnets to include in the new DB subnet group if created."
+  default     = []
+}
+
 variable "security_groups" {
   type        = list(string)
   description = "Security groups to apply to the instances."

--- a/rdsinstance/versions.tf
+++ b/rdsinstance/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
  This is an attempt to swap an already created RDS subnet group within this common module.  AWS does not allow you to remove a subnet from an rds subnet group (or replace).  We can only add and redirect rds to use the new one.

- Added bool to determine if additional rds subnet group should be created
- Added conditional to resources that if 'var.create_subnet_group' is true then to use that new subnet created and not the default one.
- Default subnet creation still exists since the default for var.create_subnet_group = false and will use the default subnet if no additional is created.