### PR TITLE
DP-47768 : Update runtime match live resources

### DIFF
--- a/newrelic/synthetics-certificate-alert/main.tf
+++ b/newrelic/synthetics-certificate-alert/main.tf
@@ -18,7 +18,7 @@ resource "newrelic_synthetics_cert_check_monitor" "monitor" {
   domain                 = var.domain
   locations_public       = var.locations
   runtime_type           = "NODE_API"
-  runtime_type_version   = "16.10"
+  runtime_type_version   = "22.20.0"
 
   dynamic "tag" {
     for_each = var.tags


### PR DESCRIPTION
Issue found while doing Nodejs upgrades and other version updates for dependent repositories.  I updated the newrelic synthetic monitor runtime to match what the actual live resource has- otherwise it attempts to downgrade.