### PR TITLE
DP-48455 Update GHA Role to support Immutable Subject Claims

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,6 @@
 name: PR Check
 on:
-  pull_request: {}
+  workflow_dispatch:
 
 jobs:
   check:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.134] - 2026-08-18
+- [GHA Role]
+  - Allow GHA role to support new immutable OIDC subject claims
+
 ## [1.0.133] - 2026-06-03
 - [S3 Bucket]
   - Fix invalid resource references, invalid `dynamic` block uses, and erroenous use of public bucket ACL

--- a/assume-role-alerts/README.md
+++ b/assume-role-alerts/README.md
@@ -10,7 +10,7 @@ No requirements.
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
@@ -20,7 +20,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudwatch_event_rule.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_sns_topic.alerts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
@@ -31,13 +31,13 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_role_arns"></a> [role\_arns](#input\_role\_arns) | The ARNs of the roles that should trigger an alert when assumed. | `list(string)` | n/a | yes |
 | <a name="input_topic_name"></a> [topic\_name](#input\_topic\_name) | The name of the SNS topic to which the alerts should be sent. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_sns_topic_arn"></a> [sns\_topic\_arn](#output\_sns\_topic\_arn) | The SNS topic ARN to which alerts will be published. |
 <!-- END_TF_DOCS -->

--- a/gha-environment/README.md
+++ b/gha-environment/README.md
@@ -10,15 +10,15 @@ The sections of this README between `BEGIN_TF_DOCS` and `END_TF_DOCS` are genera
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | >= 6.2 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 6.13 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | >= 6.2 |
+| ---- | ------- |
+| <a name="provider_github"></a> [github](#provider\_github) | >= 6.13 |
 
 ## Modules
 
@@ -27,7 +27,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [github_actions_environment_variable.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_environment_variable) | resource |
 | [github_repository_environment.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment) | resource |
 | [github_repository_environment_deployment_policy.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment_deployment_policy) | resource |
@@ -35,7 +35,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_branch_restriction_patterns"></a> [branch\_restriction\_patterns](#input\_branch\_restriction\_patterns) | Specify branch restrictions for the environment | `list(string)` | `[]` | no |
 | <a name="input_deployment_reviewers_teams"></a> [deployment\_reviewers\_teams](#input\_deployment\_reviewers\_teams) | Specify teams that may approve workflow runs when they access this environment | `list(string)` | `[]` | no |
 | <a name="input_deployment_reviewers_users"></a> [deployment\_reviewers\_users](#input\_deployment\_reviewers\_users) | Specify users that may approve workflow runs when they access this environment | `list(string)` | `[]` | no |

--- a/gha-role/README.md
+++ b/gha-role/README.md
@@ -6,15 +6,15 @@ This module creates an IAM role that can be assumed by GitHub Actions. The role 
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.45 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.26.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.45 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.26.0 |
 
 ## Modules
 
@@ -23,7 +23,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_role.role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.policy_attachments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.assume_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -31,19 +31,22 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_allow_legacy_subject"></a> [allow\_legacy\_subject](#input\_allow\_legacy\_subject) | Accept the legacy OIDC subject claim (repo:ORG/REPO:...) | `bool` | `true` | no |
 | <a name="input_custom_policy_json"></a> [custom\_policy\_json](#input\_custom\_policy\_json) | IAM policy document to attach inline to the role, use jsonencode() to convert Terraform language expressions to JSON | `string` | `""` | no |
 | <a name="input_gh_org"></a> [gh\_org](#input\_gh\_org) | The name of the organization that owns the repository. | `string` | n/a | yes |
 | <a name="input_gh_repo"></a> [gh\_repo](#input\_gh\_repo) | The name of the repository. | `string` | n/a | yes |
 | <a name="input_oidc_provider_arn"></a> [oidc\_provider\_arn](#input\_oidc\_provider\_arn) | The ARN of the Github Actions OIDC provider. | `string` | n/a | yes |
 | <a name="input_oidc_subject_claims"></a> [oidc\_subject\_claims](#input\_oidc\_subject\_claims) | Additional filters to use for who can assume the role. You can filter by branch, tag, or environment. | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
+| <a name="input_org_id"></a> [org\_id](#input\_org\_id) | GitHub organization ID, required unless allow\_legacy\_subject is true | `string` | `""` | no |
 | <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | IAM policies to attach to the role. | `list(string)` | n/a | yes |
+| <a name="input_repo_id"></a> [repo\_id](#input\_repo\_id) | Github repository ID, required unless allow\_legacy\_subject is true | `string` | `""` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The name of the role to create. | `string` | n/a | yes |
 | <a name="input_role_path"></a> [role\_path](#input\_role\_path) | The path for the role. | `string` | `"/soe/"` | no |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | n/a |
 <!-- END_TF_DOCS -->

--- a/gha-role/main.tf
+++ b/gha-role/main.tf
@@ -1,5 +1,7 @@
 locals {
-  trust_policy = var.custom_policy_json != "" ? var.custom_policy_json : data.aws_iam_policy_document.assume_policy.json
+  trust_policy   = var.custom_policy_json != "" ? var.custom_policy_json : data.aws_iam_policy_document.assume_policy.json
+  subject_prefix = var.allow_legacy_subject ? "repo:${var.gh_org}/${var.gh_repo}" : "repo:${var.gh_org}@${var.org_id}/${var.gh_repo}@${var.repo_id}"
+
 }
 
 data "aws_iam_policy_document" "assume_policy" {
@@ -18,7 +20,7 @@ data "aws_iam_policy_document" "assume_policy" {
     condition {
       test = "StringLike"
       values = [
-        for oidc_subject_claim in var.oidc_subject_claims : "repo:${var.gh_org}/${var.gh_repo}:${oidc_subject_claim}"
+        for oidc_subject_claim in var.oidc_subject_claims : "${local.subject_prefix}:${oidc_subject_claim}"
       ]
       variable = "token.actions.githubusercontent.com:sub"
     }

--- a/gha-role/variables.tf
+++ b/gha-role/variables.tf
@@ -61,12 +61,20 @@ variable "org_id" {
   type        = string
   description = "GitHub organization ID, required unless allow_legacy_subject is true"
   default     = ""
+  validation {
+    condition     = var.allow_legacy_subject || var.org_id != ""
+    error_message = "org_id is required when allow_legacy_subject is false."
+  }
 }
 
 variable "repo_id" {
   type        = string
   description = "Github repository ID, required unless allow_legacy_subject is true"
   default     = ""
+  validation {
+    condition     = var.allow_legacy_subject || var.org_id != ""
+    error_message = "org_id is required when allow_legacy_subject is false."
+  }
 }
 
 # if templated (default) trust policy will not be used

--- a/gha-role/variables.tf
+++ b/gha-role/variables.tf
@@ -61,19 +61,22 @@ variable "org_id" {
   type        = string
   description = "GitHub organization ID, required unless allow_legacy_subject is true"
   default     = ""
-  validation {
-    condition     = var.allow_legacy_subject || var.org_id != ""
-    error_message = "org_id is required when allow_legacy_subject is false."
-  }
 }
 
 variable "repo_id" {
   type        = string
   description = "Github repository ID, required unless allow_legacy_subject is true"
   default     = ""
-  validation {
-    condition     = var.allow_legacy_subject || var.org_id != ""
-    error_message = "org_id is required when allow_legacy_subject is false."
+}
+
+# Variable validation blocks can't reference other variables before version Terraform 1.9
+# so we have to use this precondition
+resource "terraform_data" "validate_subject_config" {
+  lifecycle {
+    precondition {
+      condition     = var.allow_legacy_subject || (var.org_id != "" && var.repo_id != "")
+      error_message = "org_id and repo_id are required when allow_legacy_subject is false."
+    }
   }
 }
 

--- a/gha-role/variables.tf
+++ b/gha-role/variables.tf
@@ -43,6 +43,32 @@ variable "oidc_subject_claims" {
   default = ["*"]
 }
 
+# OIDC subject claim formats:
+# Legacy: repo:octo-org/octo-repo:ref:refs/heads/main
+# Immutable: repo:octo-org@${org_id}/octo-repo@${repo_id}:ref:refs/heads/main
+
+# Repos created after 07-15-2026 emit an immutable subject claim
+# Set allow_legacy_subject to false for new repos created after this date or if opting in to use new immutable claims
+# Immutable claims require org_id and repo_id
+# https://github.com/aws-actions/configure-aws-credentials/tree/v6/#immutable-subject-claims
+variable "allow_legacy_subject" {
+  type        = bool
+  description = "Accept the legacy OIDC subject claim (repo:ORG/REPO:...)"
+  default     = true
+}
+
+variable "org_id" {
+  type        = string
+  description = "GitHub organization ID, required unless allow_legacy_subject is true"
+  default     = ""
+}
+
+variable "repo_id" {
+  type        = string
+  description = "Github repository ID, required unless allow_legacy_subject is true"
+  default     = ""
+}
+
 # if templated (default) trust policy will not be used
 variable "custom_policy_json" {
   type        = string

--- a/gha_pipeline/README.md
+++ b/gha_pipeline/README.md
@@ -12,3 +12,52 @@ Once the pipeline has been configured, a Github Action can be written that pulls
     role-to-assume: arn:aws:iam::12345:role/my-project-actions-role
     aws-region: us-east-1
 ```
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.26.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.60.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [aws_iam_role.role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.policy_attachments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_policy_document.assume_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_allow_legacy_subject"></a> [allow\_legacy\_subject](#input\_allow\_legacy\_subject) | Accept the legacy OIDC subject claim (repo:ORG/REPO:...) | `bool` | `true` | no |
+| <a name="input_custom_policy_json"></a> [custom\_policy\_json](#input\_custom\_policy\_json) | IAM policy document to attach inline to the role, use jsonencode() to convert Terraform language expressions to JSON | `string` | `""` | no |
+| <a name="input_gh_org"></a> [gh\_org](#input\_gh\_org) | n/a | `string` | n/a | yes |
+| <a name="input_gh_repo"></a> [gh\_repo](#input\_gh\_repo) | n/a | `string` | n/a | yes |
+| <a name="input_oidc_provider_arn"></a> [oidc\_provider\_arn](#input\_oidc\_provider\_arn) | n/a | `string` | n/a | yes |
+| <a name="input_oidc_subject_claims"></a> [oidc\_subject\_claims](#input\_oidc\_subject\_claims) | n/a | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
+| <a name="input_org_id"></a> [org\_id](#input\_org\_id) | GitHub organization ID, required unless allow\_legacy\_subject is true | `string` | `""` | no |
+| <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | n/a | `list(string)` | n/a | yes |
+| <a name="input_repo_id"></a> [repo\_id](#input\_repo\_id) | Github repository ID, required unless allow\_legacy\_subject is true | `string` | `""` | no |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | n/a | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | ARN of the IAM role created for the GitHub Actions pipeline |
+| <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | value of the IAM role name created for the GitHub Actions pipeline |
+| <a name="output_policy_attachment_ids"></a> [policy\_attachment\_ids](#output\_policy\_attachment\_ids) | List of policy attachment IDs for the IAM role |
+<!-- END_TF_DOCS -->

--- a/gha_pipeline/main.tf
+++ b/gha_pipeline/main.tf
@@ -1,5 +1,6 @@
 locals {
-  trust_policy = var.custom_policy_json != "" ? var.custom_policy_json : data.aws_iam_policy_document.assume_policy.json
+  trust_policy   = var.custom_policy_json != "" ? var.custom_policy_json : data.aws_iam_policy_document.assume_policy.json
+  subject_prefix = var.allow_legacy_subject ? "repo:${var.gh_org}/${var.gh_repo}" : "repo:${var.gh_org}@${var.org_id}/${var.gh_repo}@${var.repo_id}"
 }
 
 
@@ -14,7 +15,7 @@ data "aws_iam_policy_document" "assume_policy" {
     condition {
       test = "StringLike"
       values = [
-        for oidc_subject_claim in var.oidc_subject_claims : "repo:${var.gh_org}/${var.gh_repo}:${oidc_subject_claim}"
+        for oidc_subject_claim in var.oidc_subject_claims : "${local.subject_prefix}:${oidc_subject_claim}"
       ]
       variable = "token.actions.githubusercontent.com:sub"
     }

--- a/gha_pipeline/variables.tf
+++ b/gha_pipeline/variables.tf
@@ -26,6 +26,32 @@ variable "oidc_subject_claims" {
   default = ["*"]
 }
 
+# OIDC subject claim formats:
+# Legacy: repo:octo-org/octo-repo:ref:refs/heads/main
+# Immutable: repo:octo-org@${org_id}/octo-repo@${repo_id}:ref:refs/heads/main
+
+# Repos created after 07-15-2026 emit an immutable subject claim
+# Set allow_legacy_subject to false for new repos created after this date or if opting in to use new immutable claims
+# Immutable claims require org_id and repo_id
+# https://github.com/aws-actions/configure-aws-credentials/tree/v6/#immutable-subject-claims
+variable "allow_legacy_subject" {
+  type        = bool
+  description = "Accept the legacy OIDC subject claim (repo:ORG/REPO:...)"
+  default     = true
+}
+
+variable "org_id" {
+  type        = string
+  description = "GitHub organization ID, required unless allow_legacy_subject is true"
+  default     = ""
+}
+
+variable "repo_id" {
+  type        = string
+  description = "Github repository ID, required unless allow_legacy_subject is true"
+  default     = ""
+}
+
 # if templated (default) trust policy will not be used
 variable "custom_policy_json" {
   type        = string

--- a/gha_pipeline/variables.tf
+++ b/gha_pipeline/variables.tf
@@ -44,19 +44,21 @@ variable "org_id" {
   type        = string
   description = "GitHub organization ID, required unless allow_legacy_subject is true"
   default     = ""
-  validation {
-    condition     = var.allow_legacy_subject || var.org_id != ""
-    error_message = "org_id is required when allow_legacy_subject is false."
-  }
 }
 
 variable "repo_id" {
   type        = string
   description = "Github repository ID, required unless allow_legacy_subject is true"
   default     = ""
-  validation {
-    condition     = var.allow_legacy_subject || var.repo_id != ""
-    error_message = "repo_id is required when allow_legacy_subject is false."
+}
+
+# Variable validation blocks can't reference other variables before Terraform 1.9, so we have to use this precondition
+resource "terraform_data" "validate_subject_config" {
+  lifecycle {
+    precondition {
+      condition     = var.allow_legacy_subject || (var.org_id != "" && var.repo_id != "")
+      error_message = "org_id and repo_id are required when allow_legacy_subject is false."
+    }
   }
 }
 

--- a/gha_pipeline/variables.tf
+++ b/gha_pipeline/variables.tf
@@ -44,12 +44,20 @@ variable "org_id" {
   type        = string
   description = "GitHub organization ID, required unless allow_legacy_subject is true"
   default     = ""
+  validation {
+    condition     = var.allow_legacy_subject || var.org_id != ""
+    error_message = "org_id is required when allow_legacy_subject is false."
+  }
 }
 
 variable "repo_id" {
   type        = string
   description = "Github repository ID, required unless allow_legacy_subject is true"
   default     = ""
+  validation {
+    condition     = var.allow_legacy_subject || var.repo_id != ""
+    error_message = "repo_id is required when allow_legacy_subject is false."
+  }
 }
 
 # if templated (default) trust policy will not be used

--- a/jump-box/README.md
+++ b/jump-box/README.md
@@ -90,15 +90,15 @@ aws ssm start-session \
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.45 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.26.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.45 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.26.0 |
 
 ## Modules
 
@@ -107,7 +107,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_instance_profile.profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.jump](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -119,7 +119,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_ami"></a> [ami](#input\_ami) | The ami to use for the jump box. If the SSM Agent is not already installed on the ami, it should be installed through the user\_data variable. | `string` | n/a | yes |
 | <a name="input_instance_tags"></a> [instance\_tags](#input\_instance\_tags) | Additional tags to apply to the EC2 instance. | `map(string)` | `{}` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The instance type to use for the instance. | `string` | `"t4g.nano"` | no |
@@ -133,7 +133,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_jump_box_instance"></a> [jump\_box\_instance](#output\_jump\_box\_instance) | n/a |
 | <a name="output_jump_box_security_group"></a> [jump\_box\_security\_group](#output\_jump\_box\_security\_group) | n/a |
 <!-- END_TF_DOCS -->

--- a/newrelic/alert-workflow/variables.tf
+++ b/newrelic/alert-workflow/variables.tf
@@ -97,14 +97,14 @@ variable "webhook_channels" {
       teams_adaptive_card   (bool)      — use the newer Adaptive Card format for MS Teams instead of the legacy MessageCard (only applicable if payload is omitted or uses the built-in Teams template)
   EOT
   type = list(object({
-    name                     = string
-    url                      = optional(string, "")
-    channel_name             = optional(string, null)
-    destination_id           = optional(string, null)
-    payload                  = optional(string, null)
-    payload_label            = optional(string, null)
-    source_label             = optional(string, null)
-    custom_headers           = optional(map(string), {})
+    name           = string
+    url            = optional(string, "")
+    channel_name   = optional(string, null)
+    destination_id = optional(string, null)
+    payload        = optional(string, null)
+    payload_label  = optional(string, null)
+    source_label   = optional(string, null)
+    custom_headers = optional(map(string), {})
     auth_basic = optional(object({
       user     = string
       password = string

--- a/s3-backend-policy-documents/README.md
+++ b/s3-backend-policy-documents/README.md
@@ -6,14 +6,14 @@ This module creates IAM policy documents to allow access to terraform state file
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.45 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.45 |
 
 ## Modules
@@ -23,13 +23,13 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_policy_document.policy_info](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_bucket_kms_key"></a> [bucket\_kms\_key](#input\_bucket\_kms\_key) | Default bucket key for the state bucket. | `string` | n/a | yes |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of the S3 bucket used for terraform state. | `string` | n/a | yes |
 | <a name="input_state_file_paths"></a> [state\_file\_paths](#input\_state\_file\_paths) | Paths where the state file will be saved. | `list(string)` | n/a | yes |
@@ -37,7 +37,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_apply_policy_json"></a> [apply\_policy\_json](#output\_apply\_policy\_json) | n/a |
 | <a name="output_plan_policy_json"></a> [plan\_policy\_json](#output\_plan\_policy\_json) | n/a |
 <!-- END_TF_DOCS -->

--- a/s3_bucket/main.tf
+++ b/s3_bucket/main.tf
@@ -5,7 +5,7 @@ resource "random_id" "bucket_id" {
 
 locals {
   bucket_root_name = var.guarantee_uniqueness ? "${var.bucket_name}-${random_id.bucket_id.dec}" : var.bucket_name
-  account_id = data.aws_caller_identity.default.account_id
+  account_id       = data.aws_caller_identity.default.account_id
 }
 
 data "aws_caller_identity" "default" {}
@@ -16,13 +16,13 @@ data "aws_caller_identity" "default" {}
 
 data "aws_iam_policy_document" "default_key_policy" {
   statement {
-    sid = "Enable IAM User Permissions"
+    sid    = "Enable IAM User Permissions"
     effect = "Allow"
     principals {
-      type = "AWS" 
+      type        = "AWS"
       identifiers = ["arn:aws:iam::${local.account_id}:root"]
     }
-    actions = ["kms:*"]
+    actions   = ["kms:*"]
     resources = ["*"]
   }
 }
@@ -33,7 +33,7 @@ resource "aws_kms_key" "s3_key" {
   description             = "This key is used to encrypt bucket objects in ${local.bucket_root_name} and ${local.bucket_root_name}-logs"
   deletion_window_in_days = var.deletion_window_in_days # Length of time the key will be retained when a deletion is scheduled.
   enable_key_rotation     = true
-  policy = coalesce(var.kms_policy, data.aws_iam_policy_document.default_key_policy.json)
+  policy                  = coalesce(var.kms_policy, data.aws_iam_policy_document.default_key_policy.json)
 }
 
 resource "aws_kms_alias" "s3_key_alias" {
@@ -50,7 +50,7 @@ resource "aws_kms_alias" "s3_key_alias" {
 resource "aws_s3_bucket" "log_bucket" {
   count  = var.enable_logging ? 1 : 0
   bucket = "${local.bucket_root_name}-logs"
-  tags          = {
+  tags = {
     Name = "${local.bucket_root_name}-logs"
   }
 }
@@ -75,8 +75,8 @@ resource "aws_s3_bucket_acl" "log_bucket_acl" {
 
 # If bucket is NOT important, force_destroy = true; force-destroyed bucket contents are not recoverable!
 resource "aws_s3_bucket" "default_bucket" {
-  bucket        = local.bucket_root_name
-  tags          = merge(
+  bucket = local.bucket_root_name
+  tags = merge(
     var.bucket_tags,
     {
       Name = local.bucket_root_name
@@ -92,11 +92,11 @@ resource "aws_s3_bucket_public_access_block" "public_access_block" {
 
   # No sense in enabling public ACLs, since we aren't touching
   # bucket ownership settings
-  block_public_acls = true
+  block_public_acls  = true
   ignore_public_acls = true
 
   # Allow callers to enable public access thru the custom_policy variable
-  block_public_policy = false
+  block_public_policy     = false
   restrict_public_buckets = false
 }
 

--- a/s3_bucket/outputs.tf
+++ b/s3_bucket/outputs.tf
@@ -1,10 +1,10 @@
 output "full_bucket_name" {
-  value = aws_s3_bucket.default_bucket.id
+  value       = aws_s3_bucket.default_bucket.id
   description = "Full bucket name, including random characters if var.guarantee_uniqueness is used."
 }
 
 output "full_bucket_arn" {
-  value = aws_s3_bucket.default_bucket.arn
+  value       = aws_s3_bucket.default_bucket.arn
   description = "Full bucket ARN"
 }
 

--- a/ssm-session-monitor/README.md
+++ b/ssm-session-monitor/README.md
@@ -8,15 +8,15 @@ This module creates an EventBridge rule that forwards Session events to an SNS t
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.45 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.45.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.45 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.45.0 |
 
 ## Modules
 
@@ -25,7 +25,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudwatch_event_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_sns_topic.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
@@ -35,13 +35,13 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix to use for resource names. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_sns_topic_arn"></a> [sns\_topic\_arn](#output\_sns\_topic\_arn) | n/a |
 <!-- END_TF_DOCS -->
 

--- a/terraform-bootstrap/README.md
+++ b/terraform-bootstrap/README.md
@@ -6,15 +6,15 @@ This module contains the resources to initialize an AWS account for use with Ter
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.45 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.45.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.45 |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.45.0 |
 
 ## Modules
 
@@ -23,7 +23,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_dynamodb_table.lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_iam_policy.apply](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.plan](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -40,7 +40,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_create_apply_policy"></a> [create\_apply\_policy](#input\_create\_apply\_policy) | Whether to create a policy that allows the Terraform state bucket to be accessed for apply operations | `bool` | `true` | no |
 | <a name="input_create_plan_policy"></a> [create\_plan\_policy](#input\_create\_plan\_policy) | Whether to create a policy that allows the Terraform state bucket to be accessed for plan operations | `bool` | `true` | no |
 | <a name="input_iam_policy_path"></a> [iam\_policy\_path](#input\_iam\_policy\_path) | The path to use for the IAM policies | `string` | `"/soe/"` | no |
@@ -52,7 +52,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_apply_policy_arn"></a> [apply\_policy\_arn](#output\_apply\_policy\_arn) | ARN of the IAM policy used to apply Terraform state |
 | <a name="output_lock_table_arn"></a> [lock\_table\_arn](#output\_lock\_table\_arn) | ARN of the DynamoDB table used to store Terraform state lock |
 | <a name="output_lock_table_name"></a> [lock\_table\_name](#output\_lock\_table\_name) | Name of the DynamoDB table used to store Terraform state lock |


### PR DESCRIPTION
Github Repos created after 07-15-2026 emit an [immutable subject claim.](https://github.com/aws-actions/configure-aws-credentials/tree/v6/#immutable-subject-claims) This claim appends the numeric ID of the organization and of the repository after each name.

OIDC subject claim formats:
- Legacy: repo:octo-org/octo-repo:ref:refs/heads/main
- Immutable: repo:octo-org@${org_id}/octo-repo@${repo_id}:ref:refs/heads/main

This PR updates our module to support these new claims, while still supporting the legacy format. `allow_legacy_subject` is set true by default which will use the legacy subject format and should be set to false for any new repos or any repos choosing to opt in. If `allow_legacy_subject` is set to false, `org_id` and `repo_id` must be set.